### PR TITLE
Switch from PostgreSQL to MySQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
-# Use postgresql as the database for Active Record
-gem 'pg', '~> 0.18'
+# Use mysql as the database for Active Record
+gem 'mysql2', '>= 0.3.18', '< 0.5'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.4'
+# Use postgresql as the database for Active Record
+gem 'pg', '~> 0.18'
 # Use mysql as the database for Active Record
 gem 'mysql2', '>= 0.3.18', '< 0.5'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    mysql2 (0.4.10)
     netrc (0.11.0)
     nio4r (2.2.0)
     nokogiri (1.8.2)
@@ -130,7 +131,6 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
-    pg (0.21.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -295,7 +295,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mediawiki_api
-  pg (~> 0.18)
+  mysql2 (>= 0.3.18, < 0.5)
   pry
   pry-rails
   puma (~> 3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
+    pg (0.21.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -296,6 +297,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mediawiki_api
   mysql2 (>= 0.3.18, < 0.5)
+  pg (~> 0.18)
   pry
   pry-rails
   puma (~> 3.7)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generates position held verification and reconciliation pages for Wikidata
 To run this application you will need:
 
 - Ruby 2.3.0 or greater
-- PostgreSQL server
+- MySQL server
 - Yarn
 
 Follow these steps to clone and install the application:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,56 +1,25 @@
-# PostgreSQL. Versions 9.1 and up are supported.
+# MySQL. Versions 5.1.10 and up are supported.
 #
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
+# Install the MySQL driver
+#   gem install mysql2
 #
-# Configure Using Gemfile
-# gem 'pg'
+# Ensure the MySQL gem is defined in your Gemfile
+#   gem 'mysql2'
+#
+# And be sure to use new-style password hashing:
+#   http://dev.mysql.com/doc/refman/5.7/en/old-client.html
 #
 default: &default
-  adapter: postgresql
-  encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
+  adapter: mysql2
+  encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password:
+  host: localhost
 
 development:
   <<: *default
   database: verification_pages_development
-
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: verification-pages
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -71,7 +40,7 @@ test:
 # On Heroku and other platform providers, you may have a full connection URL
 # available as an environment variable. For example:
 #
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
 #
 # You can use this database configuration with:
 #
@@ -81,4 +50,5 @@ test:
 production:
   <<: *default
   database: verification_pages_production
+  username: verification-pages
   password: <%= ENV['VERIFICATION-PAGES_DATABASE_PASSWORD'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,10 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20180606082434) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "countries", force: :cascade do |t|
+  create_table "countries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.string "code"
     t.string "description_en"
@@ -25,7 +22,7 @@ ActiveRecord::Schema.define(version: 20180606082434) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pages", force: :cascade do |t|
+  create_table "pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title", null: false
     t.string "position_held_item", null: false
     t.string "parliamentary_term_item"
@@ -37,7 +34,7 @@ ActiveRecord::Schema.define(version: 20180606082434) do
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 
-  create_table "reconciliations", force: :cascade do |t|
+  create_table "reconciliations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "statement_id"
     t.string "item"
     t.string "user"
@@ -46,7 +43,7 @@ ActiveRecord::Schema.define(version: 20180606082434) do
     t.index ["statement_id"], name: "index_reconciliations_on_statement_id"
   end
 
-  create_table "statements", force: :cascade do |t|
+  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "transaction_id"
     t.string "person_item"
     t.string "person_revision"
@@ -65,7 +62,7 @@ ActiveRecord::Schema.define(version: 20180606082434) do
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 
-  create_table "verifications", force: :cascade do |t|
+  create_table "verifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "statement_id", null: false
     t.boolean "status", default: false
     t.string "user", null: false


### PR DESCRIPTION
We want to deploy this application to Wikimedia Toolforge. The default database type on there is mysql, so rather than try to do anything clever so we can continue using postgres, lets just switch to mysql.

Part of #7 