### PR TITLE
Support name correction for otherwise correct suggestions

### DIFF
--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -13,6 +13,6 @@ class VerificationsController < FrontendController
   private
 
   def verification_params
-    params.permit(%i[user status])
+    params.permit(%i[user status new_name])
   end
 end

--- a/app/services/update_statement_verification.rb
+++ b/app/services/update_statement_verification.rb
@@ -17,6 +17,7 @@ class UpdateStatementVerification < ServiceBase
   private
 
   def status
-    verification.status? ? 'correct' : 'incorrect'
+    return 'incorrect' unless verification.status?
+    verification.new_name ? 'corrected' : 'correct'
   end
 end

--- a/db/migrate/20180326074248_add_new_name_to_verification.rb
+++ b/db/migrate/20180326074248_add_new_name_to_verification.rb
@@ -1,0 +1,5 @@
+class AddNewNameToVerification < ActiveRecord::Migration[5.1]
+  def change
+    add_column :verifications, :new_name, :string, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321173159) do
+ActiveRecord::Schema.define(version: 20180326074248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20180321173159) do
     t.string "user", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "new_name"
     t.index ["statement_id"], name: "index_verifications_on_statement_id"
   end
 

--- a/spec/services/update_statement_verification_spec.rb
+++ b/spec/services/update_statement_verification_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe UpdateStatementVerification, type: :service do
+  let(:new_name) { nil }
   let(:status) { true }
   let(:statement) { double(:statement, transaction_id: '123') }
   let(:verification) do
-    double(:verification, statement: statement, status?: status)
+    double(:verification, statement: statement, status?: status, new_name: new_name)
   end
 
   let(:updater) { UpdateStatementVerification.new(verification) }
@@ -39,6 +40,18 @@ RSpec.describe UpdateStatementVerification, type: :service do
         expect(RestClient).to receive(:post)
           .with('http://example.com/suggestions/123/verifications',
                 status: 'incorrect')
+        updater.run
+      end
+    end
+
+    context 'name has been corrected' do
+      let(:status) { true }
+      let(:new_name) { 'Joseph Bloggs' }
+
+      it 'posts corrected to the suggestions store' do
+        expect(RestClient).to receive(:post)
+          .with('http://example.com/suggestions/123/verifications',
+                status: 'corrected')
         updater.run
       end
     end


### PR DESCRIPTION
This adds a migration to add a column for `new_name`, and handles `new_name` being sent back from the front-end Javascript.