### PR TITLE
Enable Webpack CSS loader

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,9 @@
 const { environment } = require('@rails/webpacker')
 const vueTemplate = require('./loaders/vue_template')
 
-environment.loaders.append('html', vueTemplate)
+environment.loaders.delete('css')
+environment.loaders.delete('sass')
+environment.loaders.append('html', vueTemplate.html)
+environment.loaders.append('css', vueTemplate.css)
+
 module.exports = environment

--- a/config/webpack/loaders/vue_template.js
+++ b/config/webpack/loaders/vue_template.js
@@ -1,4 +1,10 @@
 module.exports = {
-  test: /\.html(\.erb)?$/,
-  use: 'vue-template-loader'
+  html: {
+    test: /\.html(\.erb)?$/,
+    use: 'vue-template-loader'
+  },
+  css: {
+    test: /\.css(\.scss)?$/,
+    use: ['style-loader', 'css-loader', 'sass-loader']
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-vue": "^2.0.1",
     "js-levenshtein": "^1.1.3",
     "jsonp": "^0.2.1",
+    "sass-loader": "^6.0.7",
     "vue": "^2.5.13",
     "vue-loader": "^14.1.1",
     "vue-template-compiler": "^2.5.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,6 +1431,15 @@ clone-deep@^0.3.0:
     kind-of "^3.2.2"
     shallow-clone "^0.1.2"
 
+clone-deep@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-2.0.2.tgz#00db3a1e173656730d1188c3d6aced6d7ea97713"
+  dependencies:
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.0"
+    shallow-clone "^1.0.0"
+
 clone@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
@@ -3814,6 +3823,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+neo-async@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.0.tgz#76b1c823130cca26acfbaccc8fbaf0a2fa33b18f"
+
 node-forge@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
@@ -5285,6 +5298,16 @@ sass-loader@^6.0.6:
     lodash.tail "^4.1.1"
     pify "^3.0.0"
 
+sass-loader@^6.0.7:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.7.tgz#dd2fdb3e7eeff4a53f35ba6ac408715488353d00"
+  dependencies:
+    clone-deep "^2.0.1"
+    loader-utils "^1.0.1"
+    lodash.tail "^4.1.1"
+    neo-async "^2.5.0"
+    pify "^3.0.0"
+
 sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -5428,6 +5451,14 @@ shallow-clone@^0.1.2:
     is-extendable "^0.1.1"
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
+    mixin-object "^2.0.1"
+
+shallow-clone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
+  dependencies:
+    is-extendable "^0.1.1"
+    kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
 shebang-command@^1.2.0:


### PR DESCRIPTION
This allows CSS to be compiled into the tool's JS using an import EG:
  `import template from './app.html?style=./app.css.scss'`