### PR TITLE
Improvements to “Type:” dropdown filter

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -1,5 +1,6 @@
 .verification-tool__blank-slate {
     text-align: center;
+    margin-top: 1em; // same margin-top as on the table
     padding: 3em;
     border: 1px solid #ccc;
 }

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -20,7 +20,12 @@
     </span>
   </div>
   <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
-    No statements
+    <div v-if="displayType === 'all'">
+      No statements
+    </div>
+    <div v-else>
+      No “{{ displayType }}” statements – <a v-on:click="displayType = 'all'">Try showing all statements</a>
+    </div>
   </div>
   <div v-if="loaded && currentStatements.length > 0">
     <table style="width: 100%; margin-top: 1em; border: 1px solid #ccc; border-collapse: collapse; table-layout: fixed;">

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -5,13 +5,13 @@
     <span style="float: right;">
       Type
       <select v-model="displayType">
-        <option value='all'>Show all</option>
-        <option>verifiable</option>
-        <option>unverifiable</option>
-        <option>reconcilable</option>
-        <option>actionable</option>
-        <option>manually_actionable</option>
-        <option>done</option>
+        <option value="all">Show all ({{ countStatementsOfType('all') }})</option>
+        <option value="verifiable">Verifiable ({{ countStatementsOfType('verifiable') }})</option>
+        <option value="unverifiable">Unverifiable ({{ countStatementsOfType('unverifiable') }})</option>
+        <option value="reconcilable">Reconcilable ({{ countStatementsOfType('reconcilable') }})</option>
+        <option value="actionable">Actionable ({{ countStatementsOfType('actionable') }})</option>
+        <option value="manually_actionable">Manually actionable ({{ countStatementsOfType('manually_actionable') }})</option>
+        <option value="done">Done ({{ countStatementsOfType('done') }})</option>
       </select>
       &nbsp;&nbsp;
       Statement

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -6,12 +6,12 @@
       Type
       <select v-model="displayType">
         <option value="all">Show all ({{ countStatementsOfType('all') }})</option>
-        <option value="verifiable">Verifiable ({{ countStatementsOfType('verifiable') }})</option>
-        <option value="unverifiable">Unverifiable ({{ countStatementsOfType('unverifiable') }})</option>
-        <option value="reconcilable">Reconcilable ({{ countStatementsOfType('reconcilable') }})</option>
-        <option value="actionable">Actionable ({{ countStatementsOfType('actionable') }})</option>
-        <option value="manually_actionable">Manually actionable ({{ countStatementsOfType('manually_actionable') }})</option>
-        <option value="done">Done ({{ countStatementsOfType('done') }})</option>
+        <option value="verifiable" v-bind:disabled="countStatementsOfType('verifiable') === 0">Verifiable ({{ countStatementsOfType('verifiable') }})</option>
+        <option value="unverifiable" v-bind:disabled="countStatementsOfType('unverifiable') === 0">Unverifiable ({{ countStatementsOfType('unverifiable') }})</option>
+        <option value="reconcilable" v-bind:disabled="countStatementsOfType('reconcilable') === 0">Reconcilable ({{ countStatementsOfType('reconcilable') }})</option>
+        <option value="actionable" v-bind:disabled="countStatementsOfType('actionable') === 0">Actionable ({{ countStatementsOfType('actionable') }})</option>
+        <option value="manually_actionable" v-bind:disabled="countStatementsOfType('manually_actionable') === 0">Manually actionable ({{ countStatementsOfType('manually_actionable') }})</option>
+        <option value="done" v-bind:disabled="countStatementsOfType('done') === 0">Done ({{ countStatementsOfType('done') }})</option>
       </select>
       &nbsp;&nbsp;
       Statement

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -93,6 +93,13 @@ export default template({
     },
     nextStatement: function () {
       this.statementIndex = this.statementIndex + 1
+    },
+    countStatementsOfType: function (type) {
+      if (type !== 'all') {
+        return this.statements.filter(s => s.type === type).length
+      } else {
+        return this.statements.length
+      }
     }
   }
 })


### PR DESCRIPTION
Fixes #77 by disabling “Type:” options if there are no statements with that type.

And probably fixes #75 for now, by at least showing the number of statements with each type. (#75 included a mockup of a much more "dashboardy" display of these totals, but maybe, for now, we can see how far this tiny change gets us, and revisit if people don’t find it obvious enough.)