### PR TITLE
Improve layout of main controls

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -9,6 +9,20 @@ $color_pale_green: #e6f9e2;
 $color_mid_grey: #999;
 $color_pale_grey: #eee;
 
+@mixin clearfix() {
+    zoom: 1;
+
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+    }
+
+    &:after {
+        clear: both;
+    }
+}
+
 .verification-tool__table,
 .verification-tool__blank-slate {
     margin-top: 1em;
@@ -65,6 +79,22 @@ $color_pale_grey: #eee;
     font-size: 0.8em;
     font-weight: bold;
     display: block;
+}
+
+.verification-tool__controls {
+    @include clearfix();
+    margin: 0 -0.5em -0.5em -0.5em;
+
+    // Compensate for vertical padding on buttons.
+    .mw-ui-button {
+        margin-top: -0.546875em;
+        margin-bottom: -0.546875em;
+    }
+}
+
+.verification-tool__controls__group {
+    float: left;
+    padding: 1em 0.5em;
 }
 
 .verification-tool__statement-controls {

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -1,23 +1,38 @@
 <div id="verification-tool">
-  <div v-if="loaded">
-    <button v-on:click="prevStatement()" class="mw-ui-button">Previous</button>
-    <button v-on:click="nextStatement()" class="mw-ui-button">Next</button>
-    <span style="float: right;">
-      Type
-      <select v-model="displayType">
+  <div v-if="loaded" class="verification-tool__controls">
+    <div class="verification-tool__controls__group">
+      <label for="displayType">Type</label>
+      <select v-model="displayType" id="displayType">
         <option value="all">Show all ({{ countStatementsOfType('all') }})</option>
-        <option value="verifiable" v-bind:disabled="countStatementsOfType('verifiable') === 0">Verifiable ({{ countStatementsOfType('verifiable') }})</option>
-        <option value="unverifiable" v-bind:disabled="countStatementsOfType('unverifiable') === 0">Unverifiable ({{ countStatementsOfType('unverifiable') }})</option>
-        <option value="reconcilable" v-bind:disabled="countStatementsOfType('reconcilable') === 0">Reconcilable ({{ countStatementsOfType('reconcilable') }})</option>
-        <option value="actionable" v-bind:disabled="countStatementsOfType('actionable') === 0">Actionable ({{ countStatementsOfType('actionable') }})</option>
-        <option value="manually_actionable" v-bind:disabled="countStatementsOfType('manually_actionable') === 0">Manually actionable ({{ countStatementsOfType('manually_actionable') }})</option>
-        <option value="done" v-bind:disabled="countStatementsOfType('done') === 0">Done ({{ countStatementsOfType('done') }})</option>
+        <option value="verifiable" v-bind:disabled="countStatementsOfType('verifiable') === 0">
+          Verifiable ({{ countStatementsOfType('verifiable') }})
+        </option>
+        <option value="unverifiable" v-bind:disabled="countStatementsOfType('unverifiable') === 0">
+          Unverifiable ({{ countStatementsOfType('unverifiable') }})
+        </option>
+        <option value="reconcilable" v-bind:disabled="countStatementsOfType('reconcilable') === 0">
+          Reconcilable ({{ countStatementsOfType('reconcilable') }})
+        </option>
+        <option value="actionable" v-bind:disabled="countStatementsOfType('actionable') === 0">
+          Actionable ({{ countStatementsOfType('actionable') }})
+        </option>
+        <option value="manually_actionable" v-bind:disabled="countStatementsOfType('manually_actionable') === 0">
+          Manually actionable ({{ countStatementsOfType('manually_actionable') }})
+        </option>
+        <option value="done" v-bind:disabled="countStatementsOfType('done') === 0">
+          Done ({{ countStatementsOfType('done') }})
+        </option>
       </select>
-      &nbsp;&nbsp;
-      Statement
-      <input v-model:number="displayIndex" type="number" style="width: 40px;">
+    </div>
+    <div class="verification-tool__controls__group" style="float: right;">
+      <button v-on:click="prevStatement()" class="mw-ui-button">Previous</button>
+      <button v-on:click="nextStatement()" class="mw-ui-button">Next</button>
+    </div>
+    <div class="verification-tool__controls__group" style="float: right;">
+      <label for="displayIndex">Statement</label>
+      <input v-model:number="displayIndex" type="number" style="width: 4em;" id="displayIndex">
       of {{ currentStatements.length }}
-    </span>
+    </div>
   </div>
   <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
     <div v-if="displayType === 'all'">


### PR DESCRIPTION
Group the statement navigation controls together, away from the Type filter control, so it’s more obvious what "Next"/"Previous" relates to.

Also, tidy up the vertical padding.

<img width="1085" alt="screen shot 2018-04-09 at 12 33 17" src="https://user-images.githubusercontent.com/739624/38495646-3ffeb80a-3bf2-11e8-9bcd-2f5c76e2c90c.png">


Fixes #74.