### PR TITLE
Fix syntax error in app/services/update_verification_templates.rb

### DIFF
--- a/app/services/update_verification_templates.rb
+++ b/app/services/update_verification_templates.rb
@@ -13,13 +13,15 @@ class UpdateVerificationTemplates < ServiceBase
 
   def run
     templates.each do |template|
-      template_name = "#{page_title}/#{template.basename('.mediawiki.erb')}"
-      print "Updating #{template_name}... "
-      client.create_page(template_name, render(template))
-    rescue MediawikiApi::ApiError => ex
-      puts "error (#{ex.message})"
-    else
-      puts 'done'
+      begin
+        template_name = "#{page_title}/#{template.basename('.mediawiki.erb')}"
+        print "Updating #{template_name}... "
+        client.create_page(template_name, render(template))
+      rescue MediawikiApi::ApiError => ex
+        puts "error (#{ex.message})"
+      else
+        puts 'done'
+      end
     end
   end
 


### PR DESCRIPTION
I'm not sure this code is actually being used, but I ran into a syntax error when trying to deploy the app to production. It seems that this error only show up in production because files are lazy-loaded in development, so this file isn't getting loaded.

Fixes #90 