### PR TITLE
Mark duplicate statements as verified

### DIFF
--- a/app/controllers/verifications_controller.rb
+++ b/app/controllers/verifications_controller.rb
@@ -5,12 +5,7 @@
 class VerificationsController < FrontendController
   def create
     statement = Statement.find_by!(transaction_id: params.fetch(:id))
-    statement.verifications.create!(verification_params)
-
-    # If there was a correction to the name, save that on the
-    # statement so it'll be used for reconciliation and actioning:
-    statement.update_attributes(person_name: params[:new_name]) if params[:new_name]
-
+    CreateVerification.run(statement: statement, params: verification_params)
     respond_with(statement)
   end
 

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -34,6 +34,15 @@ class Statement < ApplicationRecord
     Rails.cache.write(force_type_key, type, expires_in: 5.minutes)
   end
 
+  def duplicate_statements
+    Statement.where(
+      person_name: person_name,
+      electoral_district_name: electoral_district_name,
+      electoral_district_item: electoral_district_item,
+      fb_identifier: fb_identifier
+    ).where.not(id: id).order(created_at: :asc)
+  end
+
   private
 
   def force_type_key
@@ -42,15 +51,6 @@ class Statement < ApplicationRecord
 
   def detect_duplicate_statements
     self.duplicate ||= duplicate_statements.present?
-  end
-
-  def duplicate_statements
-    Statement.where(
-      person_name: person_name,
-      electoral_district_name: electoral_district_name,
-      electoral_district_item: electoral_district_item,
-      fb_identifier: fb_identifier
-    ).where.not(id: id).order(created_at: :asc)
   end
 
   def verify_duplicate!

--- a/app/services/create_verification.rb
+++ b/app/services/create_verification.rb
@@ -1,0 +1,19 @@
+# Service for creating a new verification
+class CreateVerification < ServiceBase
+  def initialize(statement:, params:)
+    @statement = statement
+    @params = params
+  end
+
+  def run
+    statement.verifications.create!(params)
+
+    # If there was a correction to the name, save that on the
+    # statement so it'll be used for reconciliation and actioning:
+    statement.update_attributes(person_name: params[:new_name]) if params[:new_name]
+  end
+
+  private
+
+  attr_reader :statement, :params
+end

--- a/app/services/create_verification.rb
+++ b/app/services/create_verification.rb
@@ -8,6 +8,11 @@ class CreateVerification < ServiceBase
   def run
     statement.verifications.create!(params)
 
+    # Find duplicate statements and update their verifications
+    statement.duplicate_statements.each do |duplicate_statement|
+      duplicate_statement.verifications.create!(params)
+    end
+
     # If there was a correction to the name, save that on the
     # statement so it'll be used for reconciliation and actioning:
     statement.update_attributes(person_name: params[:new_name]) if params[:new_name]

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe CreateVerification, type: :service do
-  let(:statement) { create(:statement) }
+  let(:statement_params) { { person_name: 'Alice', electoral_district_name: 'Foo', electoral_district_item: 'Q123', fb_identifier: '444333' } }
+  let(:statement) { create(:statement, statement_params) }
 
   context 'with valid params' do
     subject { CreateVerification.new(statement: statement, params: { user: 'foo', status: 'true', new_name: 'baz' }) }
@@ -17,6 +18,11 @@ RSpec.describe CreateVerification, type: :service do
     it 'updates the statement with new_name, if relevant' do
       subject.run
       expect(statement.person_name).to eq('baz')
+    end
+
+    it 'adds verification to duplicate statements' do
+      statement2 = create(:statement, statement_params.merge(transaction_id: '456'))
+      expect { subject.run }.to change { statement2.verifications.count }.by(1)
     end
   end
 end

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreateVerification, type: :service do
+  let(:statement) { create(:statement) }
+
+  context 'with valid params' do
+    subject { CreateVerification.new(statement: statement, params: { user: 'foo', status: 'true', new_name: 'baz' }) }
+
+    before { allow(UpdateStatementVerification).to receive(:run) }
+
+    it 'creates a verification' do
+      expect { subject.run }.to change { statement.verifications.count }.by(1)
+    end
+
+    it 'updates the statement with new_name, if relevant' do
+      subject.run
+      expect(statement.person_name).to eq('baz')
+    end
+  end
+end


### PR DESCRIPTION
This ensures that when a verifications is created for a statement, any duplicates of that statement also get verified.

I've also taken the opportunity to move the controller action's logic into a service object, rather than continue to bloat the controller action.

Fixes https://github.com/mysociety/verification-pages/issues/89