### PR TITLE
After creating the Vue app, remove the "install our JavaScript" prompt

### DIFF
--- a/app/javascript/packs/verification_tool.js
+++ b/app/javascript/packs/verification_tool.js
@@ -2,6 +2,19 @@ import Vue from 'vue'
 import App from '../app'
 import wikilink from '../components/wikilink'
 
+function removeInstallPrompt() {
+  var installPrompt = document.getElementById('js-verification-tool');
+  // It'd be more robust to get the install prompt by a special class
+  // we add to it, but the version of the cmbox template on Wikidata
+  // doesn't have the 'class' parameter, so do this another way:
+  while (installPrompt && installPrompt.className != 'layouttemplate plainlinks') {
+    installPrompt = installPrompt.nextElementSibling;
+  }
+  if (installPrompt) {
+    installPrompt.style.display = 'none';
+  }
+}
+
 Vue.component('wikilink', wikilink)
 
 window.addEventListener('load', () => {
@@ -9,4 +22,5 @@ window.addEventListener('load', () => {
                      .appendChild(document.createElement('verification-tool'))
 
   const app = new Vue({ el, render: h => h(App) })
+  removeInstallPrompt();
 })

--- a/app/views/general/frontend.html.erb
+++ b/app/views/general/frontend.html.erb
@@ -14,6 +14,16 @@
           <div class="mw-parser-output">
             <h1><span class="mw-headline">Dashboard of statements</span></h1>
             <div id="js-verification-tool"></div>
+            <!-- Add the currently expected tailing text so we can see that
+                 the prompt to install the JavaScript is removed -->
+            <p><br /></p>
+            <table class="layouttemplate plainlinks">
+              <tr>
+                <td>You can contribute your own verifications to
+                this page by installing some JavaScript to your
+                common.js</td>
+              </tr>
+            </table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
It was weird that the page was still telling you to install the
JavaScript extension even after you'd done that successfully. This
change means it'll be removed if the JavaScript is loaded succesfully.

Fixes #70