### PR TITLE
Add rake task to verify historic duplicates

### DIFF
--- a/lib/tasks/verify_historic_duplicates.rake
+++ b/lib/tasks/verify_historic_duplicates.rake
@@ -1,0 +1,12 @@
+task verify_historic_duplicates: :environment do
+  Statement.original.each do |statement|
+    latest_verification = statement.latest_verification
+    next if latest_verification.blank?
+    statement.duplicate_statements.each do |duplicate_statement|
+      duplicate_statement.verifications.find_or_create_by!(
+        user: latest_verification.user,
+        status: latest_verification.status
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a small rake task that goes through all the original statements and then verifies any unverified duplicates.

Fixes #99 