### PR TITLE
Wire up country model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 2.5.0
 env:
   - RAILS_ENV=test
+before_install:
+  - gem update --system
 script:
   - bundle exec rake db:create db:schema:load db:test:prepare
   - bundle exec rspec --color --format documentation

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -57,6 +57,6 @@ class PagesController < ApplicationController
   def page_params
     params.require(:page).permit(:title, :position_held_item,
                                  :parliamentary_term_item, :reference_url,
-                                 :require_parliamentary_group)
+                                 :require_parliamentary_group, :country_id)
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Country < ApplicationRecord
+  has_many :pages
+
   validates :name, presence: true
   validates :code, presence: true, length: { in: 2..3 }
   validates :description_en, presence: true

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -3,6 +3,7 @@
 # Verification page object
 class Page < ApplicationRecord
   has_many :statements
+  belongs_to :country
 
   validates :title, presence: true
   validates :position_held_item, presence: true

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -43,6 +43,13 @@
     </div>
     <%= f.error_span(:reference_url) %>
   </div>
+  <div class="form-group">
+    <%= f.label :country_id, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.collection_select :country_id, Country.all, :id, :name, class: 'control-label col-lg-2', prompt: true %>
+    </div>
+    <%= f.error_span(:country_id) %>
+  </div>
   <div class="form-check">
     <%= f.check_box :require_parliamentary_group %>
     <%= f.label :require_parliamentary_group, class: 'form-check-label' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -7,6 +7,7 @@
     <tr>
       <th><%= model_class.human_attribute_name(:id) %></th>
       <th><%= model_class.human_attribute_name(:title) %></th>
+      <th><%= model_class.human_attribute_name(:country) %></th>
       <th><%= model_class.human_attribute_name(:position_held_item) %></th>
       <th><%= model_class.human_attribute_name(:parliamentary_term_item) %></th>
       <th><%= model_class.human_attribute_name(:reference_url) %></th>
@@ -19,6 +20,7 @@
       <tr>
         <td><%= link_to page.id, page_path(page) %></td>
         <td><%= page.title %></td>
+        <td><%= link_to page.country.name, page.country %></td>
         <td><%= page.position_held_item %></td>
         <td><%= page.parliamentary_term_item %></td>
         <td><%= page.reference_url %></td>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -12,6 +12,8 @@
   <dd><%= @page.parliamentary_term_item %></dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= @page.reference_url %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:country_id) %>:</strong></dt>
+  <dd><%= link_to @page.country.name, @page.country %></dd>
   <dt><strong><%= model_class.human_attribute_name(:require_parliamentary_group) %>:</strong></dt>
   <dd><%= @page.require_parliamentary_group %></dd>
 </dl>

--- a/db/migrate/20180517094057_make_page_country_id_required.rb
+++ b/db/migrate/20180517094057_make_page_country_id_required.rb
@@ -1,0 +1,5 @@
+class MakePageCountryIdRequired < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :pages, :country_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180515082942) do
+ActiveRecord::Schema.define(version: 20180517094057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20180515082942) do
     t.boolean "require_parliamentary_group", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "country_id"
+    t.bigint "country_id", null: false
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PagesController, type: :controller do
   # adjust the attributes here as well.
   let(:valid_attributes) do
     { title: 'Page title', position_held_item: 'Q1',
-      parliamentary_term_item: 'Q2', reference_url: 'http://example.com' }
+      parliamentary_term_item: 'Q2', reference_url: 'http://example.com', country_id: country.id }
   end
 
   let(:invalid_attributes) do
@@ -19,6 +19,8 @@ RSpec.describe PagesController, type: :controller do
   # in order to pass any filters (e.g. authentication) defined in
   # PagesController. Be sure to keep this updated too.
   let(:valid_session) { {} }
+
+  let(:country) { create(:country) }
 
   describe 'GET #index' do
     it 'returns a success response' do

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title 'Test page'
     position_held_item 'Q1'
     reference_url 'http://example.com'
+    country
   end
 end


### PR DESCRIPTION
Now that we've added a `Country` model (https://github.com/mysociety/verification-pages/pull/95) and updated existing pages to have a `country_id` (https://github.com/mysociety/verification-pages/pull/101) we're finally ready to actually wire up the country model.

This change adds the Rails-level bits and pieces needed to properly associate pages with countries. I've also updated the pages views so that you can select a country from a dropdown when creating or editing a page, and see the country when viewing a page.

Fixes https://github.com/mysociety/verification-pages/issues/61

## Screenshots

### Adding a new country

<img width="643" alt="Adding a new country" src="https://user-images.githubusercontent.com/22996/40188020-e33f833e-59f0-11e8-8dee-d8ef00f1d9f1.png">

### Editing an existing country

<img width="703" alt="Editing an existing country" src="https://user-images.githubusercontent.com/22996/40188028-ea1c98e0-59f0-11e8-86e0-3b2fd66dad0d.png">
