### PR TITLE
Add statement statistics page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger
   # console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
     ast (2.4.0)
     bindex (0.5.0)
@@ -54,6 +56,8 @@ GEM
     coderay (1.1.2)
     commonjs (0.2.7)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
@@ -81,6 +85,7 @@ GEM
       thor (>= 0.13.6)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.9.3)
@@ -130,6 +135,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (2.0.5)
     puma (3.11.2)
     rack (2.0.3)
     rack-cors (1.0.2)
@@ -216,6 +222,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -262,6 +269,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webpacker (3.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -300,6 +311,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
   webpacker (~> 3.2)
 
 BUNDLED WITH

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -8,6 +8,10 @@ class StatementsController < FrontendController
     end
   end
 
+  def statistics
+    @country_statements = StatementsStatistics.new.statistics
+  end
+
   def show
     statement = Statement.find_by!(transaction_id: params.fetch(:id))
     statement.force_type!(params[:force_type]) if params[:force_type]

--- a/app/lib/position_statistics.rb
+++ b/app/lib/position_statistics.rb
@@ -1,0 +1,29 @@
+class PositionStatistics
+  attr_reader :position
+
+  def initialize(position:, statements:, existing_positions:)
+    @position = position
+    @statements = statements
+    @existing_positions = existing_positions
+  end
+
+  def page_exists
+    existing_positions.include?(position)
+  end
+
+  def unchecked
+    statements.count { |s| s['verification_status'].nil? }
+  end
+
+  def correct
+    statements.count { |s| s['verification_status'] == 'correct' }
+  end
+
+  def incorrect
+    statements.count { |s| s['verification_status'] == 'incorrect' }
+  end
+
+  private
+
+  attr_reader :statements, :existing_positions
+end

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -1,0 +1,32 @@
+class StatementsStatistics
+  def initialize(suggestion_store_url: 'https://suggestions-store.mysociety.org')
+    @suggestion_store_url = suggestion_store_url
+  end
+
+  def statistics
+    countries.map do |country|
+      statements = JSON.parse(RestClient.get(country['export_json_url']))
+      grouped_statements = statements.group_by { |s| s['position_item'] }
+      position_stats = grouped_statements.map do |position, position_statements|
+        PositionStatistics.new(
+          position: position,
+          statements: position_statements,
+          existing_positions: existing_positions
+        )
+      end
+      [country['code'], position_stats]
+    end.to_h
+  end
+
+  private
+
+  attr_reader :suggestion_store_url
+
+  def countries
+    JSON.parse(RestClient.get(URI.join(suggestion_store_url, '/export/countries.json').to_s))
+  end
+
+  def existing_positions
+    @existing_positions ||= Page.pluck(:position_held_item)
+  end
+end

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -1,0 +1,25 @@
+<% @country_statements.each do |country_code, statements| %>
+  <h2><%= country_code %></h2>
+  <table class="wikitable">
+    <thead>
+      <tr>
+        <th>Wikidata position</th>
+        <th>Page exists</th>
+        <th>Unchecked</th>
+        <th>Correct</th>
+        <th>Incorrect</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% statements.each do |statement| %>
+      <tr>
+        <td><%= link_to statement.position, "https://www.wikidata.org/wiki/#{statement.position}" %></td>
+        <td><%= statement.page_exists %></td>
+        <td><%= statement.unchecked %></td>
+        <td><%= statement.correct %></td>
+        <td><%= statement.incorrect %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
   resources :pages
 
   # Frontend
-  resources :statements, only: %i[index show]
+  resources :statements, only: %i[index show] do
+    collection do
+      get 'statistics'
+    end
+  end
   resources :verifications, only: %i[create]
   resources :reconciliations, only: %i[create]
 

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe StatementsStatistics do
+  describe '#statistics' do
+    before do
+      stub_request(:get, 'https://suggestions-store.mysociety.org/export/countries.json')
+        .to_return(body: '[{"code": "ca", "export_json_url": "https://suggestions-store.mysociety.org/export/ca.json"}]')
+      body = [
+        {
+          id: 1,
+          verification_status: 'correct',
+          position_item: 'Q15964890'
+        },
+        {
+          id: 2,
+          verification_status: 'correct',
+          position_item: 'Q15964890'
+        },
+        {
+          id: 3,
+          verification_status: 'incorrect',
+          position_item: 'Q15964890'
+        }
+      ]
+      stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
+        .to_return(body: JSON.generate(body))
+    end
+    it 'returns a hash of country stats' do
+      statement_statistics = StatementsStatistics.new
+      position_stats = statement_statistics.statistics['ca'].first
+      expect(position_stats.position).to eq('Q15964890')
+      expect(position_stats.correct).to eq(2)
+      expect(position_stats.incorrect).to eq(1)
+      expect(position_stats.unchecked).to eq(0)
+      expect(position_stats.page_exists).to eq(false)
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!


### PR DESCRIPTION
This adds a new page which shows stats about the countries and positions that we already have statements for. This should allow us to figure out which pages need creating and what needs verifying.

Fixes https://github.com/mysociety/verification-pages/issues/104

<img width="493" alt="screen shot 2018-05-31 at 15 59 20" src="https://user-images.githubusercontent.com/22996/40790812-d5a6ea02-64ed-11e8-8606-db64c90d6b52.png">
