### PR TITLE
Add pry-rails for better console and debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   # console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'webmock'
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.6)
+      pry (>= 0.10.4)
     public_suffix (2.0.5)
     puma (3.11.2)
     rack (2.0.3)
@@ -295,6 +297,7 @@ DEPENDENCIES
   mediawiki_api
   pg (~> 0.18)
   pry
+  pry-rails
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.4)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ The test suite can run by:
 
     rspec
 
+## Console
+
+The Rails console allows you to play with the application's objects from the
+command line. Run the following to start a console:
+
+    rails console
+
+## Debugging
+
+If you need to debug part of the application drop a `binding.pry` call into the
+code, when the code is executed, e.g. by visiting a URL that uses the code in
+a browser, it will pause at the `binding.pry` call and drop you into a console
+where you can inspect the current execution environment. See the [pry
+docs](https://github.com/pry/pry) for more information.
+
 ## Troubleshooting
 
 If `foreman start` just exits with:


### PR DESCRIPTION
This adds the `pry-rails` gem, which provides Rails integration for pry. This means that `rails console` will use pry instead of irb. It also means that `binding.pry` is available.

Fixes #109 