### PR TITLE
Handle people being merged into someone else after reconciliation

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -14,7 +14,7 @@ class StatementDecorator < SimpleDelegator
 
   def done?
     verified? && reconciled? &&
-      person_item.present? && person_item == data&.person &&
+      person_matches? &&
       electoral_district_item.present? && electoral_district_item == data&.district &&
       parliamentary_term_item.present? && parliamentary_term_item == data&.term &&
       (parliamentary_group_item.blank? || parliamentary_group_item == data&.group)
@@ -40,5 +40,11 @@ class StatementDecorator < SimpleDelegator
 
   def reconciled?
     person_item.present?
+  end
+
+  private
+
+  def person_matches?
+    person_item.present? && [data&.person, data&.merged_then_deleted].include?(person_item)
   end
 end

--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -23,7 +23,7 @@ class RetrievePositionData < ServiceBase
 
   def query
     <<~SPARQL
-      SELECT DISTINCT ?person ?revision ?position ?start_of_term ?start_date ?term ?group ?district
+      SELECT DISTINCT ?person ?merged_then_deleted ?revision ?position ?start_of_term ?start_date ?term ?group ?district
       WHERE {
         %<person_bind>s
         ?position ps:P39 wd:%<position_held_item>s .
@@ -36,6 +36,7 @@ class RetrievePositionData < ServiceBase
         OPTIONAL { ?position pq:P4100 ?group . }
         OPTIONAL { ?position pq:P768 ?district . }
         OPTIONAL { ?position pq:P580 ?start_date . }
+        OPTIONAL { ?merged_then_deleted owl:sameAs ?person }
       }
     SPARQL
   end

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -110,6 +110,8 @@ class StatementClassifier
   end
 
   def position_data_for_statement(statement)
-    position_held_data.detect { |data| data.person == statement.person_item }
+    position_held_data.detect { |data|
+      [data.person, data.merged_then_deleted].include?(statement.person_item)
+    }
   end
 end


### PR DESCRIPTION
Prior to this commit, a statement that's been successfully actioned and
goes to "done" will move back to "actionable" if they're later merged
into someone else (which effectively deletes the original person we
reconciled and against, and redirects them to the person they were
merged into).

This commit changes the query we make to find current members of the
legislature to include previous item IDs the people might have had in
the past, and will match the person based on those item IDs as well as
the person's current item ID when looking them up.

This should fix a good proportion of the cases in #105, where people are
still in "actionable" although the have the right P39 already.