### PR TITLE
Statistics page: link to any page(s) that exist for each position

### DIFF
--- a/app/lib/position_statistics.rb
+++ b/app/lib/position_statistics.rb
@@ -7,8 +7,8 @@ class PositionStatistics
     @existing_positions = existing_positions
   end
 
-  def page_exists
-    existing_positions.include?(position)
+  def pages
+    @pages ||= existing_positions.fetch(position, Set.new).sort
   end
 
   def unchecked

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -27,6 +27,12 @@ class StatementsStatistics
   end
 
   def existing_positions
-    @existing_positions ||= Page.pluck(:position_held_item)
+    return @position_to_page_titles if @position_to_page_titles
+    # Make a Hash mapping from a position to a Set of associated page titles:
+    @position_to_page_titles = Hash.new { |h, k| h[k] = Set.new }
+    Page.pluck(:position_held_item, :title).inject(@position_to_page_titles) do |acc, (position, page_title)|
+      acc[position].add(page_title)
+      acc
+    end
   end
 end

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -4,7 +4,7 @@
     <thead>
       <tr>
         <th>Wikidata position</th>
-        <th>Page exists</th>
+        <th>Page</th>
         <th>Unchecked</th>
         <th>Correct</th>
         <th>Incorrect</th>
@@ -14,7 +14,11 @@
       <% statements.each do |statement| %>
       <tr>
         <td><%= link_to statement.position, "https://www.wikidata.org/wiki/#{statement.position}" %></td>
-        <td><%= statement.page_exists %></td>
+        <td><% if statement.pages.each do |page_title| %>
+          <a href="https://www.wikidata.org/wiki/<%= page_title %>"><%= page_title %></a>
+          <% end.empty? %>
+          missing
+        <% end %></td>
         <td><%= statement.unchecked %></td>
         <td><%= statement.correct %></td>
         <td><%= statement.incorrect %></td>

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -24,6 +24,7 @@ describe StatementsStatistics do
       ]
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
         .to_return(body: JSON.generate(body))
+      create(:page, position_held_item: 'Q15964890')
     end
     it 'returns a hash of country stats' do
       statement_statistics = StatementsStatistics.new
@@ -32,7 +33,7 @@ describe StatementsStatistics do
       expect(position_stats.correct).to eq(2)
       expect(position_stats.incorrect).to eq(1)
       expect(position_stats.unchecked).to eq(0)
-      expect(position_stats.page_exists).to eq(false)
+      expect(position_stats.pages).to eq(['Test page'])
     end
   end
 end


### PR DESCRIPTION
This means that you can go straight from the statistics page (showing
which pages still have things to do) to the page where you can deal with
them.

Fixes #115