### PR TITLE
Move verification_page rake task into lib/tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,39 +9,3 @@ require 'rubocop/rake_task'
 
 Rails.application.load_tasks
 RuboCop::RakeTask.new
-
-namespace :verification_page do
-  desc 'Generate verification page for the page_title given'
-  task :generate, %i[page_title] => %i[environment] do |_, args|
-    abort('Require page title argument') if args.page_title.blank?
-    puts GenerateVerificationPage.run(args.page_title)
-  end
-
-  desc 'Update verification page for the page_title given'
-  task :update, %i[page_title] => %i[environment] do |_, args|
-    begin
-      abort('Require page title argument') if args.page_title.blank?
-      UpdateVerificationPage.run(args.page_title)
-      puts 'Verification page now visible at: ' \
-        "https://#{ENV['WIKIDATA_SITE']}/wiki/#{args.page_title}"
-    rescue MediawikiApi::EditError => ex
-      puts ex.response.inspect
-    end
-  end
-
-  namespace :update do
-    desc 'Update verification page templates'
-    task templates: :environment do
-      UpdateVerificationTemplates.run(
-        "User:#{ENV.fetch('WIKIDATA_USERNAME')}/verification"
-      )
-    end
-
-    desc 'Update verification page javascript'
-    task javascript: :environment do
-      UpdateVerificationJavascript.run(
-        "User:#{ENV.fetch('WIKIDATA_USERNAME')}/verification.js"
-      )
-    end
-  end
-end

--- a/lib/tasks/verification_page.rake
+++ b/lib/tasks/verification_page.rake
@@ -1,0 +1,35 @@
+namespace :verification_page do
+  desc 'Generate verification page for the page_title given'
+  task :generate, %i[page_title] => %i[environment] do |_, args|
+    abort('Require page title argument') if args.page_title.blank?
+    puts GenerateVerificationPage.run(args.page_title)
+  end
+
+  desc 'Update verification page for the page_title given'
+  task :update, %i[page_title] => %i[environment] do |_, args|
+    begin
+      abort('Require page title argument') if args.page_title.blank?
+      UpdateVerificationPage.run(args.page_title)
+      puts 'Verification page now visible at: ' \
+        "https://#{ENV['WIKIDATA_SITE']}/wiki/#{args.page_title}"
+    rescue MediawikiApi::EditError => ex
+      puts ex.response.inspect
+    end
+  end
+
+  namespace :update do
+    desc 'Update verification page templates'
+    task templates: :environment do
+      UpdateVerificationTemplates.run(
+        "User:#{ENV.fetch('WIKIDATA_USERNAME')}/verification"
+      )
+    end
+
+    desc 'Update verification page javascript'
+    task javascript: :environment do
+      UpdateVerificationJavascript.run(
+        "User:#{ENV.fetch('WIKIDATA_USERNAME')}/verification.js"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Code for custom rake tasks traditionally lives in `lib/tasks/` in a file with a `.rake` extension, to prevent the top-level `Rakefile` from getting too cluttered.