### PR TITLE
Prevent live HTTP requests being made during tests

### DIFF
--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'rails_helper'
 
 RSpec.describe CreateVerification, type: :service do
@@ -12,6 +13,45 @@ RSpec.describe CreateVerification, type: :service do
     }
   end
   let(:statement) { create(:statement, statement_params) }
+
+  before do
+    scheme_data = {
+      'results' => [
+        {
+          'id' => 1,
+          'name' => 'wikidata-persons'
+        },
+        {
+          'id' => 2,
+          'name' => 'wikidata-memberships'
+        },
+        {
+          'id' => 3,
+          'name' => 'wikidata-organizations'
+        },
+        {
+          'id' => 4,
+          'name' => 'ms-uuid-persons'
+        },
+        {
+          'id' => 5,
+          'name' => 'ms-uuid-memberships'
+        },
+        {
+          'id' => 6,
+          'name' => 'ms-uuid-organizations'
+        },
+        {
+          'id' => 7,
+          'name' => 'facebook-persons'
+        }
+      ]
+    }
+    stub_request(:get, 'https://id-mapping-store.mysociety.org/scheme')
+      .to_return(status: 200, body: JSON.pretty_generate(scheme_data))
+    stub_request(:get, 'https://id-mapping-store.mysociety.org/identifier/7/444333')
+      .to_return(status: 404, body: '')
+  end
 
   context 'with valid params' do
     subject do

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,1 @@
 require 'webmock/rspec'
-
-WebMock.allow_net_connect!


### PR DESCRIPTION
It's not good to rely on a live API service (in this case id-mapping-store) in running tests; for example, it means you can't run the tests offline and it means they run slower. This pull request uses WebMock to stub the requests that the tests make to id-mapping-store and changes WebMock's configuration so that if any unstubbed HTTP requests are added in future, we'll get an error.

Fixes #112 