### PR TITLE
Add load statements button to pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@
 
 # Controller to manage verification pages
 class PagesController < ApplicationController
-  before_action :set_page, only: %i[show edit update destroy]
+  before_action :set_page, only: %i[show edit update destroy load]
 
   # GET /pages
   def index
@@ -44,6 +44,12 @@ class PagesController < ApplicationController
   def destroy
     @page.destroy
     redirect_to pages_url, notice: 'Page was successfully destroyed.'
+  end
+
+  # POST /pages/1/load
+  def load
+    statements = LoadStatements.run(@page.title)
+    redirect_to @page, notice: "#{statements.count} Statements loaded"
   end
 
   private

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -3,6 +3,10 @@
   <h1><%= t '.title', default: model_class.model_name.human.titleize %></h1>
 </div>
 
+<% if flash[:notice] %>
+  <p class="flash flash-notice"><%= flash[:notice] %></p>
+<% end %>
+
 <dl class="dl-horizontal">
   <dt><strong><%= model_class.human_attribute_name(:title) %>:</strong></dt>
   <dd><%= @page.title %></dd>
@@ -16,6 +20,8 @@
   <dd><%= link_to @page.country.name, @page.country %></dd>
   <dt><strong><%= model_class.human_attribute_name(:require_parliamentary_group) %>:</strong></dt>
   <dd><%= @page.require_parliamentary_group %></dd>
+  <dt><strong>Statements</strong></dt>
+  <dd><%= @page.statements.count %></dd>
 </dl>
 
 <%= link_to t('.back', default: t("helpers.links.back")),
@@ -27,3 +33,5 @@
               method: 'delete',
               data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },
               class: 'btn btn-danger' %>
+
+<%= link_to 'Load statements from suggestions-store', load_page_path(@page), method: :post, class: 'btn btn-default' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@
 Rails.application.routes.draw do
   resources :countries
   # Admin
-  resources :pages
+  resources :pages do
+    member do
+      post :load
+    end
+  end
 
   # Frontend
   resources :statements, only: %i[index show] do


### PR DESCRIPTION
This adds a new button to an individual page which allows you to load the associated statements from the suggestions-store via the web UI.

Part of https://github.com/mysociety/verification-pages/issues/34