### PR TITLE
 Record the last time a Statement was actioned with a new actioned_at field

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -14,7 +14,7 @@ class StatementsController < FrontendController
 
   def show
     statement = Statement.find_by!(transaction_id: params.fetch(:id))
-    statement.force_type!(params[:force_type]) if params[:force_type]
+    statement.record_actioned! if params[:force_type] == 'done'
     respond_with(statement)
   end
 end

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -70,8 +70,8 @@ class StatementClassifier
   end
 
   def statement_type(statement)
-    if statement.force_type
-      statement.force_type.to_sym
+    if statement.recently_actioned?
+      :done
     elsif statement.done?
       :done
     elsif statement.reconciled? && (statement.started_before_term? || statement.qualifiers_contradicting?)

--- a/db/migrate/20180606082434_add_actioned_at_to_statement.rb
+++ b/db/migrate/20180606082434_add_actioned_at_to_statement.rb
@@ -1,0 +1,5 @@
+class AddActionedAtToStatement < ActiveRecord::Migration[5.1]
+  def change
+    add_column :statements, :actioned_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517094057) do
+ActiveRecord::Schema.define(version: 20180606082434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20180517094057) do
     t.string "fb_identifier"
     t.boolean "duplicate", default: false
     t.bigint "page_id"
+    t.datetime "actioned_at"
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe StatementsController, type: :controller do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let!(:statement) { create(:statement) }
+
+  let(:show_parameters) do
+    { id: '123', format: 'json' }
+  end
+
+  describe "GET #show" do{id: '123', format: 'json'}
+    it 'returns http success for a transaction that exists' do
+      get :show, params: show_parameters
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'does not update the actioned_at time' do
+      get :show, params: show_parameters
+      expect(statement.actioned_at).to be_nil
+    end
+
+    context 'when force_type: done is provided' do
+      let!(:show_parameters) do
+        { id: '123', format: 'json', force_type: 'done' }
+      end
+
+      it 'should set actioned_at to a current timestamp' do
+        travel_to Time.zone.local(2017, 11, 24, 01, 04, 44) do
+          get :show, params: show_parameters
+          statement.reload
+          expect(statement.actioned_at).to eq(DateTime.new(2017, 11, 24, 01, 04, 44))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are going to use this new actioned_at field to support a new
"reverted" state, which detects when we have enacted a suggestion (i.e.
taken it from "actionable" -> "done") but that position held statement was
later changed in Wikidata so it's no longer detected as "done".

This pull request, however, should just keep the current behaviour the same as
before, but relying on the actioned_at column of the statements table,
instead of keys with a 5 minute timeout in the Rails cache.