### PR TITLE
Add "reverted" for where actioned statements no longer match Wikidata

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -42,6 +42,10 @@ class StatementDecorator < SimpleDelegator
     person_item.present?
   end
 
+  def actioned?
+    actioned_at?
+  end
+
   private
 
   def person_matches?

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -22,6 +22,9 @@
         <option value="done" v-bind:disabled="countStatementsOfType('done') === 0">
           Done ({{ countStatementsOfType('done') }})
         </option>
+        <option value="reverted" v-bind:disabled="countStatementsOfType('reverted') === 0">
+          Reverted ({{ countStatementsOfType('reverted') }})
+        </option>
       </select>
     </div>
     <div class="verification-tool__controls__group" style="float: right;">

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -9,6 +9,7 @@ import reconcilableComponent from './components/reconcilable'
 import actionableComponent from './components/actionable'
 import manuallyActionableComponent from './components/manually_actionable'
 import doneComponent from './components/done'
+import revertedComponent from './components/reverted'
 
 export default template({
   data () {
@@ -40,6 +41,7 @@ export default template({
         case 'actionable': return actionableComponent
         case 'manually_actionable': return manuallyActionableComponent
         case 'done': return doneComponent
+        case 'reverted': return revertedComponent
       }
     },
     statement: function () {

--- a/app/javascript/components/reverted.html
+++ b/app/javascript/components/reverted.html
@@ -1,0 +1,3 @@
+<span>
+  This statement statement was actioned, but has since been changed on Wikidata
+</span>

--- a/app/javascript/components/reverted.js
+++ b/app/javascript/components/reverted.js
@@ -1,0 +1,5 @@
+import template from './reverted.html'
+
+export default template({
+  data () { return {} }
+})

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -24,15 +24,15 @@ class Statement < ApplicationRecord
   end
 
   def record_actioned!
-    self.actioned_at = DateTime.now
+    self.actioned_at = Time.now
     save!
   end
 
   def recently_actioned?
     # Was this statement actioned in the last 5 minutes?
     return false unless actioned_at
-    time_difference_in_days = DateTime.now - actioned_at
-    time_difference_in_days * (24 * 60) < 5
+    time_difference_seconds = Time.now - actioned_at
+    (time_difference_seconds / 60.0) < 5
   end
 
   def duplicate_statements

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -22,7 +22,7 @@ class StatementClassifier
   # actionable
   # manually_actionable
   # done(able)
-  #
+  # reverted
 
   def verifiable
     classified_statements.fetch(:verifiable, [])
@@ -46,6 +46,10 @@ class StatementClassifier
 
   def done
     classified_statements.fetch(:done, [])
+  end
+
+  def reverted
+    classified_statements.fetch(:reverted, [])
   end
 
   def to_a
@@ -74,6 +78,8 @@ class StatementClassifier
       :done
     elsif statement.done?
       :done
+    elsif statement.actioned?
+      :reverted
     elsif statement.reconciled? && (statement.started_before_term? || statement.qualifiers_contradicting?)
       :manually_actionable
     elsif statement.reconciled?

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when unverifiable' do
@@ -73,6 +74,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when verified' do
@@ -83,6 +85,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when statement is actionable' do
@@ -96,6 +99,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to eq(statements) }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when statement is actionable, but has been actioned in the last 5 minutes' do
@@ -107,6 +111,7 @@ RSpec.describe StatementClassifier, type: :service do
         position_held.group = nil
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at?).and_return(true)
       end
       after do
         travel_back
@@ -117,9 +122,10 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
     end
 
-    context 'when statement is actionable, but has been actioned over 5 minutes ago' do
+    context 'when statement would be actionable, but has been actioned over 5 minutes ago' do
       before do
         supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
         travel_to supposed_current_time
@@ -128,6 +134,7 @@ RSpec.describe StatementClassifier, type: :service do
         position_held.group = nil
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at?).and_return(true)
       end
       after do
         travel_back
@@ -135,9 +142,10 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.verifiable).to be_empty }
       it { expect(classifier.unverifiable).to be_empty }
       it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to eq(statements) }
+      it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to eq(statements) }
     end
 
     context 'when district qualifier contradict' do
@@ -151,6 +159,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to eq(statements) }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when group qualifier contradict' do
@@ -164,6 +173,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to eq(statements) }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when position start is 2 days before term start' do
@@ -178,6 +188,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to eq(statements) }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when the statement has been actioned' do
@@ -191,6 +202,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
     end
 
 
@@ -202,6 +214,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
     end
 
     context 'when the reconciled person has since been merged into someone else' do
@@ -229,6 +242,7 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.actionable).to be_empty }
       it { expect(classifier.manually_actionable).to be_empty }
       it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
     end
   end
 end


### PR DESCRIPTION
This is a new state to represent the fairly common situation that somone
has actioned a statement (that is: enacted it in Wikidata, moving the
statement to "done") but subsequenty it doesn't match what's in
Wikidata. This might be due to a Wikidata user reverting the change (or
a bug in our software) but in any case, we need to make sure we don't
encourage someone to try to action the satement again, which is what
would happen if it went back into the actionable state - hence this new
state instead, which doesn't prompt someone to make a change.

Note that to account for caching delays in detecting what's changed in
Wikidata, a statement still goes to "done" for 5 minutes after
actionining, regardless of whether it matches what we're getting back
from Wikidata queries - if they don't matched Wikidata more than 5
minutes after actioning, they will go to "reverted" however.