### PR TITLE
Add create/update page on Wikidata button to Pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@
 
 # Controller to manage verification pages
 class PagesController < ApplicationController
-  before_action :set_page, only: %i[show edit update destroy load]
+  before_action :set_page, only: %i[show edit update destroy load create_wikidata]
 
   # GET /pages
   def index
@@ -50,6 +50,13 @@ class PagesController < ApplicationController
   def load
     statements = LoadStatements.run(@page.title)
     redirect_to @page, notice: "#{statements.count} Statements loaded"
+  end
+
+  # POST /pages/1/create_wikidata
+  def create_wikidata
+    UpdateVerificationPage.run(@page.title)
+    redirect_to @page, notice: 'Verification page now visible at: ' \
+      "https://#{ENV['WIKIDATA_SITE']}/wiki/#{@page.title}"
   end
 
   private

--- a/app/services/concerns/wiki_client.rb
+++ b/app/services/concerns/wiki_client.rb
@@ -4,22 +4,30 @@
 module WikiClient
   extend ActiveSupport::Concern
 
-  WIKI_SITE = ENV.fetch('WIKIDATA_SITE')
-  WIKI_USERNAME = ENV.fetch('WIKIDATA_USERNAME')
-  WIKI_PASSWORD = ENV.fetch('WIKIDATA_PASSWORD')
-
   private
 
   def client
     @client ||= begin
-      client = MediawikiApi::Client.new("https://#{WIKI_SITE}/w/api.php")
+      client = MediawikiApi::Client.new("https://#{wiki_site}/w/api.php")
 
-      result = client.log_in(WIKI_USERNAME, WIKI_PASSWORD)
+      result = client.log_in(wiki_username, wiki_password)
       if result['result'] != 'Success'
         abort "MediawikiApi::Client#log_in failed: #{result}"
       end
 
       client
     end
+  end
+
+  def wiki_site
+    ENV.fetch('WIKIDATA_SITE')
+  end
+
+  def wiki_username
+    ENV.fetch('WIKIDATA_USERNAME')
+  end
+
+  def wiki_password
+    ENV.fetch('WIKIDATA_PASSWORD')
   end
 end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -35,3 +35,4 @@
               class: 'btn btn-danger' %>
 
 <%= link_to 'Load statements from suggestions-store', load_page_path(@page), method: :post, class: 'btn btn-default' %>
+<%= link_to 'Create or update verification page on Wikidata', create_wikidata_page_path(@page), method: :post, class: 'btn btn-default' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   resources :pages do
     member do
       post :load
+      post :create_wikidata
     end
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -187,4 +187,27 @@ RSpec.describe PagesController, type: :controller do
       end.to change(page.statements, :count).by(2)
     end
   end
+
+  describe 'POST #create_wikidata' do
+    let(:page) { Page.create! valid_attributes }
+
+    before do
+      allow(UpdateVerificationPage).to receive(:run)
+    end
+
+    it 'runs the UpdateVerificationPage service' do
+      expect(UpdateVerificationPage).to receive(:run).with(page.title)
+      post :create_wikidata, params: { id: page.to_param }, session: valid_session
+    end
+
+    it 'redirects to pages#show' do
+      response = post :create_wikidata, params: { id: page.to_param }, session: valid_session
+      expect(response).to redirect_to(page_path(page))
+    end
+
+    it 'sets a flash notice' do
+      post :create_wikidata, params: { id: page.to_param }, session: valid_session
+      expect(flash[:notice]).to be_present
+    end
+  end
 end


### PR DESCRIPTION
This adds a new button to the `pages#show` route which creates or updates the associated verification page on Wikidata.

<img width="856" alt="screen shot 2018-06-11 at 15 16 31" src="https://user-images.githubusercontent.com/22996/41237021-73ca83f2-6d8a-11e8-86b4-4d0e0f9405cc.png">


Part of #34 