### PR TITLE
Show the reasons why a statement is in the 'manually_actionable' state

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -20,14 +20,26 @@ class StatementDecorator < SimpleDelegator
       (parliamentary_group_item.blank? || parliamentary_group_item == data&.group)
   end
 
-  def started_before_term?
-    data&.start_date && data&.start_of_term &&
-      Date.parse(data.start_date) < Date.parse(data.start_of_term) - 1.day
+  def problems
+    electoral_district_problems +
+      parliamentary_group_problems +
+      start_date_before_term_problems
   end
 
-  def qualifiers_contradicting?
-    data&.district && electoral_district_item != data&.district ||
-      data&.group && parliamentary_group_item != data&.group
+  def start_date_before_term_problems
+    return [] unless data&.start_date && data&.start_of_term &&
+      Date.parse(data.start_date) < Date.parse(data.start_of_term) - 1.day
+    [ "On Wikidata, the position held start date (#{data&.start_date}) was before the term start date (#{data&.start_of_term})" ]
+  end
+
+  def electoral_district_problems
+    return [] unless data&.district && electoral_district_item != data&.district
+    [ "The electoral district is different in the statement (#{electoral_district_item}) and on Wikidata (#{data&.district})" ]
+  end
+
+  def parliamentary_group_problems
+    return [] unless data&.group && parliamentary_group_item != data&.group
+    [ "The parliamentary group (party) is different in the statement (#{parliamentary_group_item}) and on Wikidata (#{data&.group})" ]
   end
 
   def unverifiable?

--- a/app/javascript/components/manually_actionable.html
+++ b/app/javascript/components/manually_actionable.html
@@ -1,3 +1,9 @@
 <span>
-  This statement can't be actioned automatically and will need to be done manually
+  This statement can't be actioned automatically and will need to be done manually.
+  The problems were:
+  <ul>
+    <li v-for="problem in statement.problems">
+      {{ problem }}
+    </li>
+  </ul>
 </span>

--- a/app/javascript/components/manually_actionable.js
+++ b/app/javascript/components/manually_actionable.js
@@ -1,5 +1,6 @@
 import template from './manually_actionable.html'
 
 export default template({
-  data () { return {} }
+  data () { return {} },
+  props: ['statement']
 })

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -80,7 +80,7 @@ class StatementClassifier
       :done
     elsif statement.actioned?
       :reverted
-    elsif statement.reconciled? && (statement.started_before_term? || statement.qualifiers_contradicting?)
+    elsif statement.reconciled? && !statement.problems.empty?
       :manually_actionable
     elsif statement.reconciled?
       :actionable

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -11,7 +11,8 @@ json.statements @classifier.to_a,
   :updated_at,
   :person_name,
   :parliamentary_group_name,
-  :electoral_district_name
+  :electoral_district_name,
+  :problems
 
 json.page @classifier.page, :reference_url, :position_held_item
 

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -19,4 +19,128 @@ RSpec.describe StatementDecorator, type: :decorator do
       expect(statement.statement_uuid).to eq 'UUID'
     end
   end
+
+  context 'when electoral districts contradict' do
+    let(:object) do
+      Statement.new(
+        person_item: 'Q1',
+        electoral_district_item: 'Q789',
+      )
+    end
+    let(:position_held_data) do
+      OpenStruct.new(revision: '123', position: 'UUID', district: 'Q345')
+    end
+    let(:expected_error) do
+      'The electoral district is different in the statement (Q789) and on Wikidata (Q345)'
+    end
+    it 'should find a problem with the electoral districts' do
+      expect(statement.electoral_district_problems).to eq([ expected_error ])
+    end
+    it 'should find a problem overall' do
+      expect(statement.problems).to eq([ expected_error ])
+    end
+  end
+
+  context 'when parliamentary groups (parties) contradict' do
+    let(:object) do
+      Statement.new(
+        person_item: 'Q1',
+        parliamentary_group_item: 'Q123',
+      )
+    end
+    let(:position_held_data) do
+      OpenStruct.new(revision: '123', position: 'UUID', group: 'Q234')
+    end
+    let(:expected_error) do
+      'The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)'
+    end
+    it 'should find a problem with the parliamentary groups' do
+      expect(statement.parliamentary_group_problems).to eq([ expected_error ])
+    end
+    it 'should find a problem overall' do
+      expect(statement.problems).to eq([ expected_error ])
+    end
+  end
+
+  context 'when the position start date on Wikidata is more than 1 day before the start of the term' do
+    let(:position_held_data) do
+      OpenStruct.new(
+        revision: '123',
+        position: 'UUID',
+        start_date: '2014-01-06',
+        start_of_term: '2014-01-31'
+      )
+    end
+    let(:expected_error) do
+      'On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)'
+    end
+    it 'should find a problem with the start date' do
+      expect(statement.start_date_before_term_problems).to eq([ expected_error ])
+    end
+    it 'should find a problem overall' do
+      expect(statement.problems).to eq([ expected_error ])
+    end
+  end
+
+  context 'when the position start date on Wikidata is the day before the start of the term' do
+    let(:position_held_data) do
+      OpenStruct.new(
+        revision: '123',
+        position: 'UUID',
+        start_date: '2014-01-06',
+        start_of_term: '2014-01-07'
+      )
+    end
+    it 'should find no problem with the start date' do
+      expect(statement.start_date_before_term_problems).to be_empty
+    end
+    it 'should find no problems overall' do
+      expect(statement.problems).to be_empty
+    end
+  end
+
+  context 'when the position start date on Wikidata is the after the start of the term' do
+    let(:position_held_data) do
+      OpenStruct.new(
+        revision: '123',
+        position: 'UUID',
+        start_date: '2014-01-06',
+        start_of_term: '2014-01-04'
+      )
+    end
+    it 'should find no problem with the start date' do
+      expect(statement.start_date_before_term_problems).to be_empty
+    end
+    it 'should find no problems overall' do
+      expect(statement.problems).to be_empty
+    end
+  end
+
+  context 'when all know problems happen for the same data' do
+    let(:object) do
+      Statement.new(
+        person_item: 'Q1',
+        parliamentary_group_item: 'Q123',
+        electoral_district_item: 'Q789',
+      )
+    end
+    let(:position_held_data) do
+      OpenStruct.new(
+        revision: '123',
+        position: 'UUID',
+        start_date: '2014-01-06',
+        start_of_term: '2014-01-31',
+        district: 'Q345',
+        group: 'Q234'
+      )
+    end
+    it 'should report all those problems' do
+      expected_errors =[
+        "The electoral district is different in the statement (Q789) and on Wikidata (Q345)",
+        "The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)",
+        "On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)"
+      ]
+      expect(statement.problems).to eq(expected_errors)
+    end
+  end
 end


### PR DESCRIPTION
The first commit in this pull requests doesn't change external behaviour, just how the manually_actionable state is calculated - changing it to be a determined by whether a list of "problems" is empty or not. The second commit updates the statement JSON and frontend JavaScript to render the reasons why a statement has ended up in manually_actionable.

![manually-actionable-reasons](https://user-images.githubusercontent.com/7907/41314175-e5a215b8-6e83-11e8-99c4-5df6472fa184.png)

Fixes #81 