### PR TITLE
Fix minor problems with stubbed HTTP requests

### DIFF
--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe PagesController, type: :controller do
         }
       ]
 
-      stub_request(:get, 'https://suggestions-store.mysociety.org/export/IT/Q1.json')
+      stub_request(:get, "#{ENV.fetch('SUGGESTIONS_STORE_URL').chomp('/')}/export/IT/Q1.json")
         .to_return(body: JSON.generate(suggestions_store_response))
 
       scheme_data = {

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -160,24 +160,6 @@ RSpec.describe PagesController, type: :controller do
 
       stub_request(:get, "#{ENV.fetch('SUGGESTIONS_STORE_URL').chomp('/')}/export/IT/Q1.json")
         .to_return(body: JSON.generate(suggestions_store_response))
-
-      scheme_data = {
-        results: [
-          {
-            id: 1,
-            name: 'wikidata-persons'
-          },
-          {
-            id: 7,
-            name: 'facebook-persons'
-          }
-        ]
-      }
-
-      stub_request(:get, 'https://id-mapping-store.mysociety.org/scheme')
-        .to_return(body: JSON.pretty_generate(scheme_data))
-      stub_request(:get, "https://id-mapping-store.mysociety.org/identifier/7/175419109847284")
-        .to_return(status: 404, body: '')
     end
 
     it 'loads statements for the given page' do

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -47,9 +47,12 @@ RSpec.describe CreateVerification, type: :service do
         }
       ]
     }
-    stub_request(:get, 'https://id-mapping-store.mysociety.org/scheme')
+    id_mapping_store_base_url = ENV.fetch(
+      'ID_MAPPING_STORE_BASE_URL', 'https://id-mapping-store.mysociety.org'
+    )
+    stub_request(:get, "#{id_mapping_store_base_url}/scheme")
       .to_return(status: 200, body: JSON.pretty_generate(scheme_data))
-    stub_request(:get, 'https://id-mapping-store.mysociety.org/identifier/7/444333')
+    stub_request(:get, "#{id_mapping_store_base_url}/identifier/7/444333")
       .to_return(status: 404, body: '')
   end
 


### PR DESCRIPTION
This fixes a couple of cases where the stubbed URL should be based on an environment variable, and one instance where no requests seemed to be made to the stubbed URL in the tests, so we can save on some setup for the tests.