### PR TITLE
Add basic authentication for the admin pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The following environment variables will need to set and configured:
 In development this can be achieved by adding these to a `.env` file in the
 project root.
 
+### Optional basic auth for admin interface
+
+If you want to protect the admin interface for creating countries and pages
+then set the `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables to
+a username and password respectively. This will then require basic
+authentication before the user can log in. This is *highly recommended*
+for any public deployment.
+
 ## Running
 
 To run this application follow the steps to install above, then you can start

--- a/app/controllers/concerns/admin_authentication.rb
+++ b/app/controllers/concerns/admin_authentication.rb
@@ -1,0 +1,25 @@
+# Include this in a controller to protect it with basic auth.
+#
+# Set the ADMIN_USERNAME and ADMIN_PASSWORD environment variables to activate this module.
+module AdminAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate
+  end
+
+  def authenticate
+    return unless admin_password && admin_password
+    authenticate_or_request_with_http_basic do |username, password|
+      username == admin_username && password == admin_password
+    end
+  end
+
+  def admin_username
+    ENV['ADMIN_USERNAME']
+  end
+
+  def admin_password
+    ENV['ADMIN_PASSWORD']
+  end
+end

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,4 +1,6 @@
 class CountriesController < ApplicationController
+  include AdminAuthentication
+
   before_action :set_country, only: [:show, :edit, :update, :destroy]
 
   # GET /countries

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,8 @@
 
 # Controller to manage verification pages
 class PagesController < ApplicationController
+  include AdminAuthentication
+
   before_action :set_page, only: %i[show edit update destroy load create_wikidata]
 
   # GET /pages

--- a/app/javascript/packs/verification_tool.js
+++ b/app/javascript/packs/verification_tool.js
@@ -17,10 +17,16 @@ function removeInstallPrompt() {
 
 Vue.component('wikilink', wikilink)
 
-window.addEventListener('load', () => {
+function createVueApp() {
   const el = document.getElementById('js-verification-tool')
                      .appendChild(document.createElement('verification-tool'))
 
   const app = new Vue({ el, render: h => h(App) })
   removeInstallPrompt();
-})
+}
+
+if (document.readyState !== 'loading') {
+  createVueApp()
+} else {
+  document.addEventListener('DOMContentLoaded', createVueApp)
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :countries
   # Admin
+  resources :countries
   resources :pages do
     member do
       post :load


### PR DESCRIPTION
This adds basic auth to the countries and pages admin interfaces to prevent any unwanted changes.

At the moment I haven't written any tests for this, but I think it should hopefully be obvious enough if this isn't working.

Fixes #33 

## Notes to merger

Once this is merged we'll need to set `ADMIN_USERNAME` and `ADMIN_PASSWORD` on Toolforge in `~tools.verification-pages/verification-pages/environment_variables.sh` to enable it.