### PR TITLE
Fix JavaScript not running because 'load' had already fired

### DIFF
--- a/app/javascript/packs/verification_tool.js
+++ b/app/javascript/packs/verification_tool.js
@@ -17,10 +17,16 @@ function removeInstallPrompt() {
 
 Vue.component('wikilink', wikilink)
 
-window.addEventListener('load', () => {
+function createVueApp() {
   const el = document.getElementById('js-verification-tool')
                      .appendChild(document.createElement('verification-tool'))
 
   const app = new Vue({ el, render: h => h(App) })
   removeInstallPrompt();
-})
+}
+
+if (document.readyState !== 'loading') {
+  createVueApp()
+} else {
+  document.addEventListener('DOMContentLoaded', createVueApp)
+}


### PR DESCRIPTION
We're using the wikibits importScript function to load the JavaScript
that creates the Vue app. This loads the JavaScript asynchronously.
The Vue app was only created once the window load event had fired,
however, so (when all the page assets were cached, in particular) the
load event might have been fired before our JavaScript runs - in that
case, nothing would happen.

There are two things we should change to fix this:

1. We only need to wait for the DOM to be ready, not all the page's
   resources (e.g. images, CSS) as well, which is what waiting for the
   'load' event did.

2. We should check if the DOM is already ready before waiting for that.

This commit makes those two changes. It seems that in the course of my
testing, however, the DOM is always loaded by the time our JavaScript
runs, which suggests to me that the asynchronous JavaScript loading
code is only run once the DOM is ready. However, it doesn't hurt to
keep the code that waits for the DOMContentLoaded book, and safer
given that my testing is of quite a limited range of browsers and
quality of network connection.

Fixes #136