### PR TITLE
Add link to create missing pages to statistics page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,7 @@ class PagesController < ApplicationController
 
   # GET /pages/new
   def new
-    @page = Page.new
+    @page = Page.new(new_page_params)
   end
 
   # GET /pages/1/edit
@@ -74,5 +74,9 @@ class PagesController < ApplicationController
                                  :parliamentary_term_item, :reference_url,
                                  :require_parliamentary_group, :country_id,
                                  :csv_source_url)
+  end
+
+  def new_page_params
+    params.permit(:title, :position_held_item, :csv_source_url, :country_id)
   end
 end

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -17,7 +17,12 @@
         <td><% if statement.pages.each do |page_title| %>
           <a href="https://www.wikidata.org/wiki/<%= page_title %>"><%= page_title %></a>
           <% end.empty? %>
-          missing
+          missing (<%= link_to 'Create page', new_page_path(
+            title: "User:Verification_pages_bot/verification/#{country_code.downcase}/",
+            position_held_item: statement.position,
+            csv_source_url: "#{ENV['SUGGESTIONS_STORE_URL']}export/#{country_code.downcase}/#{statement.position}.csv",
+            country_id: Country.find_by(code: country_code.downcase)
+          ) %>)
         <% end %></td>
         <td><%= statement.unchecked %></td>
         <td><%= statement.correct %></td>

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe PagesController, type: :controller do
       get :new, params: {}, session: valid_session
       expect(response).to be_success
     end
+
+    context 'with querystring parameters' do
+      it 'uses them to populate new Page instance' do
+        get :new, params: {
+          title: 'Test title',
+          position_held_item: 'Q123321',
+          csv_source_url: 'https://example.com/export.csv'
+        }, session: valid_session
+        page = @controller.view_assigns['page']
+        expect(page.title).to eq('Test title')
+        expect(page.position_held_item).to eq('Q123321')
+        expect(page.csv_source_url).to eq('https://example.com/export.csv')
+      end
+    end
   end
 
   describe 'GET #edit' do


### PR DESCRIPTION
This adds a button to the statistics page that allows you to create a missing page, prefilling some of the parameters for you.

Related to #139 

<img width="658" alt="screen shot 2018-06-26 at 18 02 05" src="https://user-images.githubusercontent.com/22996/41927821-30c5a0b8-796b-11e8-9e03-78d4046cd9fb.png">
<img width="1030" alt="screen shot 2018-06-26 at 18 03 02" src="https://user-images.githubusercontent.com/22996/41927820-30a7d38a-796b-11e8-9535-c0a78ebddef9.png">