### PR TITLE
Ensure statements are verified before they become actionable

### DIFF
--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -82,7 +82,7 @@ class StatementClassifier
       :reverted
     elsif statement.reconciled? && !statement.problems.empty?
       :manually_actionable
-    elsif statement.reconciled?
+    elsif statement.verified? && statement.reconciled?
       :actionable
     elsif statement.verified?
       :reconcilable

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -245,5 +245,18 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.done).to eq(statements) }
       it { expect(classifier.reverted).to be_empty }
     end
+
+    context 'when the statements are reconciled but not verified' do
+      before do
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+      it { expect(classifier.verifiable).to eq(statements) }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
+    end
   end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe StatementClassifier, type: :service do
     context 'when statement is actionable' do
       before do
         position_held.group = nil
+        statement.verifications.build(status: true)
         allow(statement).to receive(:person_item).and_return('Q1')
       end
       it { expect(classifier.verifiable).to be_empty }


### PR DESCRIPTION
Now that we're dealing with external sources other than suggestions-store we have to handle the case where the external source is already reconciled to Wikidata but hasn't been verified.

This change checks that a statement has been both verified _and_ reconciled before considering it actionable.

Fixes #166 

## Note to reviewer

The first commit changes another test for the actionable state because it wasn't creating a verification in the before block. My understanding is that statements *must* be verified before they are actionable, so I _think_ it's OK to make that change, but please say if I'm wrong!