### PR TITLE
[#151] [#162] Handle statements with parliamentary groups

### DIFF
--- a/app/controllers/reconciliations_controller.rb
+++ b/app/controllers/reconciliations_controller.rb
@@ -13,6 +13,6 @@ class ReconciliationsController < FrontendController
   private
 
   def reconciliation_params
-    params.permit(%i[user item])
+    params.permit(%i[user item resource_type])
   end
 end

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -60,11 +60,20 @@ class StatementDecorator < SimpleDelegator
   end
 
   def reconciled?
-    person_item.present?
+    reconciliations.empty?
   end
 
   def actioned?
     actioned_at?
+  end
+
+  def reconciliations
+    person_reconciliations
+  end
+
+  def person_reconciliations
+    return [] if person_item.present?
+    [ 'person' ]
   end
 
   private

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -68,12 +68,18 @@ class StatementDecorator < SimpleDelegator
   end
 
   def reconciliations
-    person_reconciliations
+    person_reconciliations + party_reconciliations
   end
 
   def person_reconciliations
     return [] if person_item.present?
     [ 'person' ]
+  end
+
+  def party_reconciliations
+    return [] if !page.require_parliamentary_group? ||
+      parliamentary_group_item.present?
+    [ 'party' ]
   end
 
   private

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -52,7 +52,8 @@ class StatementDecorator < SimpleDelegator
   end
 
   def unverifiable?
-    latest_verification && latest_verification.status == false
+    unverifiable_due_to_party? ||
+      latest_verification && latest_verification.status == false
   end
 
   def verified?
@@ -85,6 +86,10 @@ class StatementDecorator < SimpleDelegator
   private
 
   attr_reader :matching_position_held_data
+
+  def unverifiable_due_to_party?
+    page.require_parliamentary_group? && parliamentary_group_name.blank? && parliamentary_group_item.blank?
+  end
 
   def person_matches?
     person_item.present? && [data&.person, data&.merged_then_deleted].include?(person_item)

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -6,8 +6,10 @@
     Loading search results...
   </span>
   <span v-if="searchResultsLoaded">
-    <h3>Create a new item</h3>
-    <button v-on:click="createPerson()">Create {{ statement.person_name }}</button>
+    <span v-if="this.searchResourceType === 'person'">
+      <h3>Create a new item</h3>
+      <button v-on:click="createPerson()">Create {{ statement.person_name }}</button>
+    </span>
     <h3>Wikidata search results</h3>
     <ul class="wd-search-results">
       <li v-for="wdResult in searchResults.fromWikidata">

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -1,6 +1,7 @@
 <span>
   <span v-if="!searchResultsLoading && !searchResultsLoaded">
-    <button v-on:click="searchForName()" class="mw-ui-button mw-ui-progressive">Search</button>
+    <button v-if="statement.reconciliations.indexOf('person') != -1" v-on:click="searchForName()" class="mw-ui-button mw-ui-progressive">Search for person</button>
+    <button v-if="statement.reconciliations.indexOf('party') != -1" v-on:click="searchForParty()" class="mw-ui-button mw-ui-progressive">Search for party</button>
   </span>
   <span v-if="searchResultsLoading">
     Loading search results...

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -20,9 +20,15 @@ export default template({
   methods: {
     searchForName: function () {
       this.searchResourceType = 'person'
+      this.search(this.statement.person_name)
+    },
+    searchForParty: function () {
+      this.searchResourceType = 'party'
+      this.search(this.statement.parliamentary_group_name)
+    },
+    search: function (searchTerm) {
       this.searchResultsLoading = true;
-      const name = this.statement.person_name
-      wikidataClient.search(name, 'en', 'en').then(data => {
+      wikidataClient.search(searchTerm, 'en', 'en').then(data => {
         console.log(data);
         this.searchResults = data;
         this.searchResultsLoaded = true;

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -8,6 +8,7 @@ export default template({
     searchResultsLoading: false,
     searchResultsLoaded: false,
     searchResults: null,
+    searchResourceType: null
   } },
   props: ['statement', 'country'],
   created: function () {
@@ -18,6 +19,7 @@ export default template({
   },
   methods: {
     searchForName: function () {
+      this.searchResourceType = 'person'
       this.searchResultsLoading = true;
       const name = this.statement.person_name
       wikidataClient.search(name, 'en', 'en').then(data => {
@@ -32,7 +34,8 @@ export default template({
         return Axios.post(ENV.url + '/reconciliations.json', {
           id: this.statement.transaction_id,
           user: wikidataClient.user,
-          item: itemID
+          item: itemID,
+          resource_type: this.searchResourceType
         })
       })
     },

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -4,7 +4,7 @@
 class Reconciliation < ApplicationRecord
   belongs_to :statement
 
-  validates :item, presence: true
+  validates :item, :resource_type, presence: true
 
   default_scope -> { order(updated_at: :asc) }
 

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -22,6 +22,7 @@ class Reconciliation < ApplicationRecord
   end
 
   def create_equivalence_claim
+    return if resource_type != 'person' || !item_changed?
     store.create_equivalence_claim("Added FB ID for #{statement.person_name}")
   end
 

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -13,7 +13,12 @@ class Reconciliation < ApplicationRecord
   private
 
   def update_statement
-    statement.update_attributes(person_item: item)
+    case resource_type
+    when 'person'
+      statement.update_attributes(person_item: item)
+    when 'party'
+      statement.update_attributes(parliamentary_group_item: item)
+    end
   end
 
   def create_equivalence_claim

--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -22,6 +22,8 @@ class LoadStatements < ServiceBase
         person_item: result[:person_item],
         electoral_district_name: result[:electoral_district_name],
         electoral_district_item: result[:electoral_district_item],
+        parliamentary_group_name: result[:parliamentary_group_name],
+        parliamentary_group_item: result[:parliamentary_group_item],
         fb_identifier: result[:fb_identifier]
       )
     end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -36,5 +36,5 @@
               data: { confirm: t('.confirm', default: t("helpers.links.confirm", default: 'Are you sure?')) },
               class: 'btn btn-danger' %>
 
-<%= link_to 'Load statements from suggestions-store', load_page_path(@page), method: :post, class: 'btn btn-default' %>
+<%= link_to 'Load statements', load_page_path(@page), method: :post, class: 'btn btn-default' %>
 <%= link_to 'Create or update verification page on Wikidata', create_wikidata_page_path(@page), method: :post, class: 'btn btn-default' %>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -12,7 +12,8 @@ json.statements @classifier.to_a,
   :person_name,
   :parliamentary_group_name,
   :electoral_district_name,
-  :problems
+  :problems,
+  :reconciliations
 
 json.page @classifier.page, :reference_url, :position_held_item
 

--- a/db/migrate/20180627114341_change_csv_source_url_column_limit.rb
+++ b/db/migrate/20180627114341_change_csv_source_url_column_limit.rb
@@ -1,0 +1,9 @@
+class ChangeCsvSourceUrlColumnLimit < ActiveRecord::Migration[5.1]
+  def up
+    change_column :pages, :csv_source_url, :string, limit: 2000
+  end
+
+  def down
+    change_column :pages, :csv_source_url, :string, limit: 255
+  end
+end

--- a/db/migrate/20180627135538_add_resource_type_to_reconciliations.rb
+++ b/db/migrate/20180627135538_add_resource_type_to_reconciliations.rb
@@ -1,0 +1,5 @@
+class AddResourceTypeToReconciliations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :reconciliations, :resource_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626085951) do
+ActiveRecord::Schema.define(version: 20180627114341) do
 
   create_table "countries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20180626085951) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "country_id", null: false
-    t.string "csv_source_url", default: "", null: false
+    t.string "csv_source_url", limit: 2000, default: "", null: false
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180627114341) do
+ActiveRecord::Schema.define(version: 20180627135538) do
 
   create_table "countries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20180627114341) do
     t.string "user"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "resource_type"
     t.index ["statement_id"], name: "index_reconciliations_on_statement_id"
   end
 

--- a/lib/tasks/add_resource_type_to_reconciliations.rake
+++ b/lib/tasks/add_resource_type_to_reconciliations.rake
@@ -1,0 +1,7 @@
+desc 'Add resource_type to existing reconciliations'
+task add_resource_type_to_reconciliations: :environment do
+  Reconciliation.where(resource_type: nil).find_each do |reconciliation|
+    reconciliation.resource_type ||= 'person'
+    reconciliation.save!
+  end
+end

--- a/spec/controllers/reconciliations_controller_spec.rb
+++ b/spec/controllers/reconciliations_controller_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe ReconciliationsController, type: :controller do
   let(:classifier) { double(:classifier) }
 
   let(:valid_attributes) do
-    { id: '123', user: 'ExampleUser', item: 'Q1', format: 'json' }
+    { id: '123', user: 'ExampleUser', item: 'Q1', resource_type: 'person',
+      format: 'json' }
   end
 
   describe 'POST #create' do
@@ -22,7 +23,8 @@ RSpec.describe ReconciliationsController, type: :controller do
       expect(Statement).to receive(:find_by!).with(transaction_id: '123')
       post :create, params: valid_attributes
       expect(relation).to have_received(:create!)
-        .with('user' => 'ExampleUser', 'item' => 'Q1')
+        .with('user' => 'ExampleUser', 'item' => 'Q1',
+              'resource_type' => 'person')
     end
 
     it 'assigns classifier' do

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -170,4 +170,21 @@ RSpec.describe StatementDecorator, type: :decorator do
       end
     end
   end
+
+  describe '#reconciliations' do
+    let(:page) { build(:page) }
+    let(:object) { build(:statement, person_item: 'Q1', page: page) }
+
+    subject { statement.reconciliations }
+
+    context 'when person has been reconciled' do
+      before { statement.person_item = 'Q1' }
+      it { is_expected.to match_array([]) }
+    end
+
+    context 'when person hasn\'t been reconciled' do
+      before { statement.person_item = nil }
+      it { is_expected.to match_array(%w[person]) }
+    end
+  end
 end

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -186,5 +186,36 @@ RSpec.describe StatementDecorator, type: :decorator do
       before { statement.person_item = nil }
       it { is_expected.to match_array(%w[person]) }
     end
+
+    context 'when page does not require a party' do
+      before { page.require_parliamentary_group = false }
+
+      context 'when party hasn\'t been reconciled' do
+        before { statement.parliamentary_group_item = nil }
+        it { is_expected.to match_array([]) }
+      end
+    end
+
+    context 'when page requires a party' do
+      before { page.require_parliamentary_group = true }
+
+      context 'when party has been reconciled' do
+        before { statement.parliamentary_group_item = 'Q1' }
+        it { is_expected.to match_array([]) }
+      end
+
+      context 'when party hasn\'t been reconciled' do
+        before { statement.parliamentary_group_item = nil }
+        it { is_expected.to match_array(%w[party]) }
+      end
+
+      context 'when neither person or party have been reconciled' do
+        before do
+          statement.person_item = nil
+          statement.parliamentary_group_item = nil
+        end
+        it { is_expected.to match_array(%w[person party]) }
+      end
+    end
   end
 end

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -20,152 +20,154 @@ RSpec.describe StatementDecorator, type: :decorator do
     end
   end
 
-  context 'when there are multiple matching statements' do
-    let(:matching_position_held_data) do
-      [
-        OpenStruct.new(person_item: 'Q1', revision: '123', position: 'UUID1'),
-        OpenStruct.new(person_item: 'Q1', revision: '234', position: 'UUID2')
-      ]
-    end
-    let(:expected_error) do
-      'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
-    end
-    it 'should find a problem with there being multiple matching statements' do
-      expect(statement.multiple_statement_problems).to eq([ expected_error ])
-    end
-  end
-
-  context 'when electoral districts contradict' do
-    let(:object) do
-      Statement.new(
-        person_item: 'Q1',
-        electoral_district_item: 'Q789',
-      )
-    end
-    let(:matching_position_held_data) do
-      [ OpenStruct.new(revision: '123', position: 'UUID', district: 'Q345') ]
-    end
-    let(:expected_error) do
-      'The electoral district is different in the statement (Q789) and on Wikidata (Q345)'
-    end
-    it 'should find a problem with the electoral districts' do
-      expect(statement.electoral_district_problems).to eq([ expected_error ])
-    end
-    it 'should find a problem overall' do
-      expect(statement.problems).to eq([ expected_error ])
-    end
-  end
-
-  context 'when parliamentary groups (parties) contradict' do
-    let(:object) do
-      Statement.new(
-        person_item: 'Q1',
-        parliamentary_group_item: 'Q123',
-      )
-    end
-    let(:matching_position_held_data) do
-      [ OpenStruct.new(revision: '123', position: 'UUID', group: 'Q234') ]
-    end
-    let(:expected_error) do
-      'The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)'
-    end
-    it 'should find a problem with the parliamentary groups' do
-      expect(statement.parliamentary_group_problems).to eq([ expected_error ])
-    end
-    it 'should find a problem overall' do
-      expect(statement.problems).to eq([ expected_error ])
-    end
-  end
-
-  context 'when the position start date on Wikidata is more than 1 day before the start of the term' do
-    let(:matching_position_held_data) do
-      [
-        OpenStruct.new(
-          revision: '123',
-          position: 'UUID',
-          start_date: '2014-01-06',
-          start_of_term: '2014-01-31'
-        )
-      ]
-    end
-    let(:expected_error) do
-      'On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)'
-    end
-    it 'should find a problem with the start date' do
-      expect(statement.start_date_before_term_problems).to eq([ expected_error ])
-    end
-    it 'should find a problem overall' do
-      expect(statement.problems).to eq([ expected_error ])
-    end
-  end
-
-  context 'when the position start date on Wikidata is the day before the start of the term' do
-    let(:matching_position_held_data) do
-      [
-        OpenStruct.new(
-          revision: '123',
-          position: 'UUID',
-          start_date: '2014-01-06',
-          start_of_term: '2014-01-07'
-        )
-      ]
-    end
-    it 'should find no problem with the start date' do
-      expect(statement.start_date_before_term_problems).to be_empty
-    end
-    it 'should find no problems overall' do
-      expect(statement.problems).to be_empty
-    end
-  end
-
-  context 'when the position start date on Wikidata is the after the start of the term' do
-    let(:matching_position_held_data) do
-      [
-        OpenStruct.new(
-          revision: '123',
-          position: 'UUID',
-          start_date: '2014-01-06',
-          start_of_term: '2014-01-04'
-        )
-      ]
-    end
-    it 'should find no problem with the start date' do
-      expect(statement.start_date_before_term_problems).to be_empty
-    end
-    it 'should find no problems overall' do
-      expect(statement.problems).to be_empty
-    end
-  end
-
-  context 'when all known problems happen for the same data' do
-    let(:object) do
-      Statement.new(
-        person_item: 'Q1',
-        parliamentary_group_item: 'Q123',
-        electoral_district_item: 'Q789',
-      )
-    end
-    let(:matching_position_held_data) do
-      [
-        OpenStruct.new(
-          revision: '123',
-          position: 'UUID',
-          start_date: '2014-01-06',
-          start_of_term: '2014-01-31',
-          district: 'Q345',
-          group: 'Q234'
-        ),
-        OpenStruct.new
-      ]
-    end
-    it 'should report all those problems' do
-      expected_errors = [
-        "The electoral district is different in the statement (Q789) and on Wikidata (Q345)",
-        "The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)",
-        "On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)",
+  describe '#problems' do
+    context 'when there are multiple matching statements' do
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(person_item: 'Q1', revision: '123', position: 'UUID1'),
+          OpenStruct.new(person_item: 'Q1', revision: '234', position: 'UUID2')
+        ]
+      end
+      let(:expected_error) do
         'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
-      ]
-      expect(statement.problems).to eq(expected_errors)
+      end
+      it 'should find a problem with there being multiple matching statements' do
+        expect(statement.multiple_statement_problems).to eq([ expected_error ])
+      end
+    end
+
+    context 'when electoral districts contradict' do
+      let(:object) do
+        Statement.new(
+          person_item: 'Q1',
+          electoral_district_item: 'Q789',
+        )
+      end
+      let(:matching_position_held_data) do
+        [ OpenStruct.new(revision: '123', position: 'UUID', district: 'Q345') ]
+      end
+      let(:expected_error) do
+        'The electoral district is different in the statement (Q789) and on Wikidata (Q345)'
+      end
+      it 'should find a problem with the electoral districts' do
+        expect(statement.electoral_district_problems).to eq([ expected_error ])
+      end
+      it 'should find a problem overall' do
+        expect(statement.problems).to eq([ expected_error ])
+      end
+    end
+
+    context 'when parliamentary groups (parties) contradict' do
+      let(:object) do
+        Statement.new(
+          person_item: 'Q1',
+          parliamentary_group_item: 'Q123',
+        )
+      end
+      let(:matching_position_held_data) do
+        [ OpenStruct.new(revision: '123', position: 'UUID', group: 'Q234') ]
+      end
+      let(:expected_error) do
+        'The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)'
+      end
+      it 'should find a problem with the parliamentary groups' do
+        expect(statement.parliamentary_group_problems).to eq([ expected_error ])
+      end
+      it 'should find a problem overall' do
+        expect(statement.problems).to eq([ expected_error ])
+      end
+    end
+
+    context 'when the position start date on Wikidata is more than 1 day before the start of the term' do
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision: '123',
+            position: 'UUID',
+            start_date: '2014-01-06',
+            start_of_term: '2014-01-31'
+          )
+        ]
+      end
+      let(:expected_error) do
+        'On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)'
+      end
+      it 'should find a problem with the start date' do
+        expect(statement.start_date_before_term_problems).to eq([ expected_error ])
+      end
+      it 'should find a problem overall' do
+        expect(statement.problems).to eq([ expected_error ])
+      end
+    end
+
+    context 'when the position start date on Wikidata is the day before the start of the term' do
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision: '123',
+            position: 'UUID',
+            start_date: '2014-01-06',
+            start_of_term: '2014-01-07'
+          )
+        ]
+      end
+      it 'should find no problem with the start date' do
+        expect(statement.start_date_before_term_problems).to be_empty
+      end
+      it 'should find no problems overall' do
+        expect(statement.problems).to be_empty
+      end
+    end
+
+    context 'when the position start date on Wikidata is the after the start of the term' do
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision: '123',
+            position: 'UUID',
+            start_date: '2014-01-06',
+            start_of_term: '2014-01-04'
+          )
+        ]
+      end
+      it 'should find no problem with the start date' do
+        expect(statement.start_date_before_term_problems).to be_empty
+      end
+      it 'should find no problems overall' do
+        expect(statement.problems).to be_empty
+      end
+    end
+
+    context 'when all known problems happen for the same data' do
+      let(:object) do
+        Statement.new(
+          person_item: 'Q1',
+          parliamentary_group_item: 'Q123',
+          electoral_district_item: 'Q789',
+        )
+      end
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision: '123',
+            position: 'UUID',
+            start_date: '2014-01-06',
+            start_of_term: '2014-01-31',
+            district: 'Q345',
+            group: 'Q234'
+          ),
+          OpenStruct.new
+        ]
+      end
+      it 'should report all those problems' do
+        expected_errors = [
+          "The electoral district is different in the statement (Q789) and on Wikidata (Q345)",
+          "The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)",
+          "On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)",
+          'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
+        ]
+        expect(statement.problems).to eq(expected_errors)
+      end
     end
   end
 end

--- a/spec/models/reconciliation_spec.rb
+++ b/spec/models/reconciliation_spec.rb
@@ -30,16 +30,36 @@ RSpec.describe Reconciliation, type: :model do
       allow(reconciliation).to receive(:statement).and_return(statement)
     end
 
-    it 'updates statement person item' do
-      expect(statement).to receive(:update_attributes)
-        .with(person_item: 'Q2').once
-      reconciliation.item = 'Q2'
-      reconciliation.save! # create
+    context 'person resource_type' do
+      before { reconciliation.resource_type = 'person' }
 
-      expect(statement).to receive(:update_attributes)
-        .with(person_item: 'Q3').once
-      reconciliation.item = 'Q3'
-      reconciliation.save! # update
+      it 'updates statement person item' do
+        expect(statement).to receive(:update_attributes)
+          .with(person_item: 'Q2').once
+        reconciliation.item = 'Q2'
+        reconciliation.save! # create
+
+        expect(statement).to receive(:update_attributes)
+          .with(person_item: 'Q3').once
+        reconciliation.item = 'Q3'
+        reconciliation.save! # update
+      end
+    end
+
+    context 'party resource_type' do
+      before { reconciliation.resource_type = 'party' }
+
+      it 'updates statement parlimentary group item' do
+        expect(statement).to receive(:update_attributes)
+          .with(parliamentary_group_item: 'Q2').once
+        reconciliation.item = 'Q2'
+        reconciliation.save! # create
+
+        expect(statement).to receive(:update_attributes)
+          .with(parliamentary_group_item: 'Q3').once
+        reconciliation.item = 'Q3'
+        reconciliation.save! # update
+      end
     end
   end
 end

--- a/spec/models/reconciliation_spec.rb
+++ b/spec/models/reconciliation_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Reconciliation, type: :model do
     it 'requires item' do
       expect(reconciliation.errors).to include(:item)
     end
+
+    it 'requires resource_type' do
+      expect(reconciliation.errors).to include(:resource_type)
+    end
   end
 
   describe 'after commit callback' do

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -65,15 +65,16 @@ RSpec.describe LoadStatements do
           %w[
             person_name person_item
             electoral_district_name electoral_district_item
+            parliamentary_group_name parliamentary_group_item
           ],
-          %w[Alice Q987 Ambridge Q1234],
-          %w[Bob Q876 Bambridge Q4321]
+          %w[Alice Q987 Ambridge Q1234 Aparty Q555],
+          %w[Bob Q876 Bambridge Q4321 Bparty Q666]
         ].map(&:to_csv).join
       end
 
       let!(:existing_statement) do
         create(:statement,
-               transaction_id: 'md5:d693e9beb0d9af365bb267982a479980',
+               transaction_id: 'md5:9e2547c61ebf3d08dc7bb67dc69a8d22',
                person_name: 'Arthur', page: page)
       end
 
@@ -82,12 +83,14 @@ RSpec.describe LoadStatements do
         expect { load_statements.run }.to change(Statement, :count).by(1)
         last_statement = Statement.last
         expect(last_statement.transaction_id).to(
-          eq 'md5:9a72129f7da4bf1d61e8e508cc5ef485'
+          eq 'md5:0d30667ad6f4d72a9a47b54cb054975b'
         )
         expect(last_statement.person_name).to eq('Bob')
         expect(last_statement.person_item).to eq('Q876')
         expect(last_statement.electoral_district_name).to eq('Bambridge')
         expect(last_statement.electoral_district_item).to eq('Q4321')
+        expect(last_statement.parliamentary_group_name).to eq('Bparty')
+        expect(last_statement.parliamentary_group_item).to eq('Q666')
       end
 
       it 'updates existing statements' do
@@ -95,12 +98,14 @@ RSpec.describe LoadStatements do
         load_statements.run
         existing_statement.reload
         expect(existing_statement.transaction_id).to(
-          eq 'md5:d693e9beb0d9af365bb267982a479980'
+          eq 'md5:9e2547c61ebf3d08dc7bb67dc69a8d22'
         )
         expect(existing_statement.person_name).to eq('Alice')
         expect(existing_statement.person_item).to eq('Q987')
         expect(existing_statement.electoral_district_name).to eq('Ambridge')
         expect(existing_statement.electoral_district_item).to eq('Q1234')
+        expect(existing_statement.parliamentary_group_name).to eq('Aparty')
+        expect(existing_statement.parliamentary_group_item).to eq('Q555')
       end
     end
   end

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -4,24 +4,40 @@ RSpec.describe LoadStatements do
   include_context 'id-mapping-store default setup'
 
   describe '#run' do
+    let(:suggestions_store_response) { '' }
+    let(:page) do
+      create(:page, csv_source_url: 'http://example.com/export.csv')
+    end
+
+    before do
+      stub_request(:get, 'http://example.com/export.csv')
+        .to_return(status: 200, body: suggestions_store_response, headers: {})
+    end
+
     context 'CSV file with transaction_id' do
-      before do
-        suggestions_store_response = [
-          %w[transaction_id person_name electoral_district_name electoral_district_item fb_identifier],
+      let(:suggestions_store_response) do
+        [
+          %w[
+            transaction_id person_name
+            electoral_district_name electoral_district_item
+            fb_identifier
+          ],
           %w[489434391472318 Alice Ambridge Q1234 10987654321],
-          %w[1656343594481923 Bob Bambridge Q4321 10987654322],
+          %w[1656343594481923 Bob Bambridge Q4321 10987654322]
         ].map(&:to_csv).join
+      end
 
+      before do
         stub_id_mapping_store(scheme_id: '7', identifier: '10987654322')
+      end
 
-        stub_request(:get, 'http://example.com/export.csv')
-          .to_return(status: 200, body: suggestions_store_response, headers: {})
-        @page = create(:page, csv_source_url: 'http://example.com/export.csv')
-        @existing_statement = create(:statement, transaction_id: '489434391472318', person_name: 'Arthur', page: @page)
+      let!(:existing_statement) do
+        create(:statement, transaction_id: '489434391472318',
+                           person_name: 'Arthur', page: page)
       end
 
       it 'creates a missing statement' do
-        load_statements = LoadStatements.new(@page.title)
+        load_statements = LoadStatements.new(page.title)
         expect { load_statements.run }.to change(Statement, :count).by(1)
         last_statement = Statement.last
         expect(last_statement.transaction_id).to eq('1656343594481923')
@@ -32,36 +48,42 @@ RSpec.describe LoadStatements do
       end
 
       it 'updates existing statements' do
-        load_statements = LoadStatements.new(@page.title)
+        load_statements = LoadStatements.new(page.title)
         load_statements.run
-        @existing_statement.reload
-        expect(@existing_statement.transaction_id).to eq('489434391472318')
-        expect(@existing_statement.person_name).to eq('Alice')
-        expect(@existing_statement.electoral_district_name).to eq('Ambridge')
-        expect(@existing_statement.electoral_district_item).to eq('Q1234')
-        expect(@existing_statement.fb_identifier).to eq('10987654321')
+        existing_statement.reload
+        expect(existing_statement.transaction_id).to eq('489434391472318')
+        expect(existing_statement.person_name).to eq('Alice')
+        expect(existing_statement.electoral_district_name).to eq('Ambridge')
+        expect(existing_statement.electoral_district_item).to eq('Q1234')
+        expect(existing_statement.fb_identifier).to eq('10987654321')
       end
     end
 
     context 'CSV file not from suggestions-store' do
-      before do
-        suggestions_store_response = [
-          %w[person_name person_item electoral_district_name electoral_district_item],
+      let(:suggestions_store_response) do
+        [
+          %w[
+            person_name person_item
+            electoral_district_name electoral_district_item
+          ],
           %w[Alice Q987 Ambridge Q1234],
           %w[Bob Q876 Bambridge Q4321]
         ].map(&:to_csv).join
+      end
 
-        stub_request(:get, 'http://example.com/export.csv')
-          .to_return(status: 200, body: suggestions_store_response, headers: {})
-        @page = create(:page, csv_source_url: 'http://example.com/export.csv')
-        @existing_statement = create(:statement, transaction_id: 'md5:d693e9beb0d9af365bb267982a479980', person_name: 'Arthur', page: @page)
+      let!(:existing_statement) do
+        create(:statement,
+               transaction_id: 'md5:d693e9beb0d9af365bb267982a479980',
+               person_name: 'Arthur', page: page)
       end
 
       it 'creates a missing statement' do
-        load_statements = LoadStatements.new(@page.title)
+        load_statements = LoadStatements.new(page.title)
         expect { load_statements.run }.to change(Statement, :count).by(1)
         last_statement = Statement.last
-        expect(last_statement.transaction_id).to eq('md5:9a72129f7da4bf1d61e8e508cc5ef485')
+        expect(last_statement.transaction_id).to(
+          eq 'md5:9a72129f7da4bf1d61e8e508cc5ef485'
+        )
         expect(last_statement.person_name).to eq('Bob')
         expect(last_statement.person_item).to eq('Q876')
         expect(last_statement.electoral_district_name).to eq('Bambridge')
@@ -69,14 +91,16 @@ RSpec.describe LoadStatements do
       end
 
       it 'updates existing statements' do
-        load_statements = LoadStatements.new(@page.title)
+        load_statements = LoadStatements.new(page.title)
         load_statements.run
-        @existing_statement.reload
-        expect(@existing_statement.transaction_id).to eq('md5:d693e9beb0d9af365bb267982a479980')
-        expect(@existing_statement.person_name).to eq('Alice')
-        expect(@existing_statement.person_item).to eq('Q987')
-        expect(@existing_statement.electoral_district_name).to eq('Ambridge')
-        expect(@existing_statement.electoral_district_item).to eq('Q1234')
+        existing_statement.reload
+        expect(existing_statement.transaction_id).to(
+          eq 'md5:d693e9beb0d9af365bb267982a479980'
+        )
+        expect(existing_statement.person_name).to eq('Alice')
+        expect(existing_statement.person_item).to eq('Q987')
+        expect(existing_statement.electoral_district_name).to eq('Ambridge')
+        expect(existing_statement.electoral_district_item).to eq('Q1234')
       end
     end
   end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -5,13 +5,10 @@ require 'rails_helper'
 RSpec.describe StatementClassifier, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
-  let(:page) do
-    double(:page, statements: statement_relation,
-                  position_held_item: 'Q2', parliamentary_term_item: 'Q3')
-  end
+  let(:page) { build(:page, parliamentary_term_item: 'Q2') }
 
   let(:data) { { person_item: 'Q1' } }
-  let(:statement) { Statement.new(data) }
+  let(:statement) { build(:statement, data.merge(page: page)) }
   let(:statements) { [statement].compact }
   let(:statement_relation) { double(:relation, to_a: statements) }
 
@@ -27,6 +24,8 @@ RSpec.describe StatementClassifier, type: :service do
     allow(Page).to receive(:find_by!)
       .with(title: 'page_title')
       .and_return(page)
+    allow(page).to receive(:statements).
+      and_return(statement_relation)
     allow(RetrievePositionData).to receive(:run)
       .with(page.position_held_item, page.parliamentary_term_item, nil)
       .and_return(position_held_data)
@@ -42,7 +41,6 @@ RSpec.describe StatementClassifier, type: :service do
   describe 'statement classification' do
     let(:data) do
       { person_item: '',
-        page: Page.new(parliamentary_term_item: 'Q2'),
         parliamentary_group_item: 'Q3',
         electoral_district_item: 'Q4' }
     end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -65,6 +65,38 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.reverted).to be_empty }
     end
 
+    context "when verifiable, but page requires a party which we don't have" do
+      before do
+        page.require_parliamentary_group = true
+        statement.parliamentary_group_name = nil
+        statement.parliamentary_group_item = nil
+      end
+
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to eq(statements) }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
+    end
+
+    context 'when verifiable, and page requires a party which we have' do
+      before do
+        page.require_parliamentary_group = true
+        statement.parliamentary_group_name = nil
+        statement.parliamentary_group_item = 'Q3'
+      end
+
+      it { expect(classifier.verifiable).to eq(statements) }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
+    end
+
     context 'when unverifiable' do
       before { statement.verifications.build(status: false) }
       it { expect(classifier.verifiable).to be_empty }


### PR DESCRIPTION
### Relevant issue(s)

Fixes #151
Fixes #162

### What does this do?

- Imports parliamentary group name/ item from source CSVs
- Output the parliamentary group in 'Statements to Action'
- Output the parliamentary group in the frontend Vue.js app
- Add functionality to the `Page#require_parliamentary_group?` boolean, if enabled:
  - Statements can't be verified if we don't at least have a parliamentary group name
  - Add 'Search for party' in the reconcile step if needed - EG if we only have a parliamentary group name and not its wikidata item ID in the source CSV
- Update the Reconciliation model to accept both `person` and `party` items
  - and change the `after_commit` callback to update the statement correctly

### What does this doesn't do?

- Creation of missing Wikidata parliamentary groups if they can't ben reconciled
- Automatically reconcile other statements with the same party, so currently users will need to Search for party for each statement

### Why was this needed?

To verify, reconcile and action statement parliamentary groups.

### Implementation notes

In 5b970ae645753c88c94f52e7d92dc17db92c3a20 I increase the lenght of the CSV source URL column as I hit the limit. IIRC MySQL used to have a 255 limit on `varchar` columns but to my surprise I didn't need change to the `text` type. We should change this works on version of MySQL on Toolforge.

There is a rake task (`rails add_resource_type_to_reconciliations`) to update old records for the new `Reconciliation#resource_type` column.

No changes have been made when actioning statements, I believe this is already handled in `wikiapi.js` but I couldn't test locally due to some incompatibilities with the running this locally. I suspect once on Wikidata this will work as expected.

### Notes to reviewer

The initial commits (987a4af713db052c708ed470136cfdbec16049d0...2219d9c5b3a84202d80703927c2e21dc8e489df5) are just refactors with no functional changes which were required to make sensible commit diffs later on.


