### PR TITLE
[#186] Ignore historical position statements

### DIFF
--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -16,6 +16,7 @@ class RetrievePositionData < ServiceBase
     run_query(format(
       query,
       position_held_item: position_held_item,
+      parliamentary_term_item: parliamentary_term_item,
       person_bind: person_bind
     ))
   end

--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -28,6 +28,7 @@ class RetrievePositionData < ServiceBase
       SELECT DISTINCT ?person ?merged_then_deleted ?revision ?position ?start_of_term ?start_date ?term ?group ?district
       WHERE {
         %<person_bind>s
+        BIND(wd:#{parliamentary_term_item} AS ?page_term)
         ?position ps:P39 wd:%<position_held_item>s .
         ?person wdt:P31 wd:Q5 ; p:P39 ?position .
         ?person schema:version ?revision .
@@ -35,10 +36,15 @@ class RetrievePositionData < ServiceBase
           ?position pq:P2937 ?term .
           OPTIONAL { ?term (wdt:P571|wdt:P580) ?start_of_term . }
         }
+        OPTIONAL { ?page_term (wdt:P571|wdt:P580) ?start_of_page_term . }
         OPTIONAL { ?position pq:P4100 ?group . }
         OPTIONAL { ?position pq:P768 ?district . }
         OPTIONAL { ?position pq:P580 ?start_date . }
         OPTIONAL { ?merged_then_deleted owl:sameAs ?person }
+        FILTER (
+          !bound(?start_of_page_term) || !bound(?start_date) ||
+          ?start_of_page_term < ?start_date
+        )
       }
     SPARQL
   end

--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -4,10 +4,11 @@
 class RetrievePositionData < ServiceBase
   include SparqlQuery
 
-  attr_reader :position_held_item, :person_item
+  attr_reader :position_held_item, :parliamentary_term_item, :person_item
 
-  def initialize(position_held_item, person_item = nil)
+  def initialize(position_held_item, parliamentary_term_item = nil, person_item = nil)
     @position_held_item = position_held_item
+    @parliamentary_term_item = parliamentary_term_item
     @person_item = person_item
   end
 

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -111,6 +111,7 @@ class StatementClassifier
   def position_held_data
     @position_held_data ||= RetrievePositionData.run(
       page.position_held_item,
+      page.parliamentary_term_item,
       person_item_from_transaction_id
     )
   end

--- a/spec/services/retrieve_position_data_spec.rb
+++ b/spec/services/retrieve_position_data_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RetrievePositionData, type: :service do
   let(:service) { RetrievePositionData.new('Q1') }
 
   describe 'initialisation' do
-    it 'assigns positioni_held_item instance variable' do
+    it 'assigns position_held_item instance variable' do
       expect(service.position_held_item).to eq 'Q1'
     end
   end

--- a/spec/services/retrieve_position_data_spec.rb
+++ b/spec/services/retrieve_position_data_spec.rb
@@ -3,11 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe RetrievePositionData, type: :service do
-  let(:service) { RetrievePositionData.new('Q1', 'Q3') }
+  let(:service) { RetrievePositionData.new('Q1', 'Q2', 'Q3') }
 
   describe 'initialisation' do
     it 'assigns position_held_item instance variable' do
       expect(service.position_held_item).to eq 'Q1'
+    end
+
+    it 'assigns parliamentary_term_item instance variable' do
+      expect(service.parliamentary_term_item).to eq 'Q2'
     end
 
     it 'assigns person_item instance variable' do

--- a/spec/services/retrieve_position_data_spec.rb
+++ b/spec/services/retrieve_position_data_spec.rb
@@ -3,11 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe RetrievePositionData, type: :service do
-  let(:service) { RetrievePositionData.new('Q1') }
+  let(:service) { RetrievePositionData.new('Q1', 'Q3') }
 
   describe 'initialisation' do
     it 'assigns position_held_item instance variable' do
       expect(service.position_held_item).to eq 'Q1'
+    end
+
+    it 'assigns person_item instance variable' do
+      expect(service.person_item).to eq 'Q3'
     end
   end
 
@@ -16,6 +20,24 @@ RSpec.describe RetrievePositionData, type: :service do
       allow(service).to receive(:query).and_return('%<position_held_item>s')
       expect(service).to receive(:run_query).with('Q1')
       service.run
+    end
+
+    context 'with person_item' do
+      it 'calls run_query with substituted person_bind' do
+        allow(service).to receive(:query).and_return('%<person_bind>s')
+        expect(service).to receive(:run_query).with('BIND(wd:Q3 AS ?person)')
+        service.run
+      end
+    end
+
+    context 'without person_item' do
+      let(:service) { RetrievePositionData.new('Q1', 'Q2') }
+
+      it 'calls run_query with no person_bind' do
+        allow(service).to receive(:query).and_return('%<person_bind>s')
+        expect(service).to receive(:run_query).with('')
+        service.run
+      end
     end
   end
 end

--- a/spec/services/retrieve_position_data_spec.rb
+++ b/spec/services/retrieve_position_data_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe RetrievePositionData, type: :service do
       service.run
     end
 
+    it 'calls run_query with substituted parliamentary_term_item' do
+      allow(service).to receive(:query).and_return('%<parliamentary_term_item>s')
+      expect(service).to receive(:run_query).with('Q2')
+      service.run
+    end
+
     context 'with person_item' do
       it 'calls run_query with substituted person_bind' do
         allow(service).to receive(:query).and_return('%<person_bind>s')

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe StatementClassifier, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:page) do
-    double(:page, statements: statement_relation, position_held_item: 'Q2')
+    double(:page, statements: statement_relation,
+                  position_held_item: 'Q2', parliamentary_term_item: 'Q3')
   end
 
   let(:data) { { person_item: 'Q1' } }
@@ -27,7 +28,7 @@ RSpec.describe StatementClassifier, type: :service do
       .with(title: 'page_title')
       .and_return(page)
     allow(RetrievePositionData).to receive(:run)
-      .with(page.position_held_item, nil)
+      .with(page.position_held_item, page.parliamentary_term_item, nil)
       .and_return(position_held_data)
   end
 


### PR DESCRIPTION
### Relevant issue(s)

Fixes #186

### What does this do?

Updates the `RetrievePositionData` SPARQL query to:
- Ignore positions statements if they started before the parliamentary term we are dealing with
- This means new positions statements will be created when statements are actioned.

### Why was this needed?

We we're modifying historical position statements with incorrect data. Instead of creating a new statement.

### Notes to reviewer

The first two commits (975f5a0f92fe4b236023edfa5bf9bea98e667a2a...5b59ef4a390e24d2902680a10d3466b258cbf05e) have nothing to do with the new implementation but cover existing functionality in `RetrievePositionData` which wasn't being tested but I felt we needed to test before making changes.
