### PR TITLE
Fix problem with multiple P39s being incorrectly detected

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -91,7 +91,11 @@ class StatementDecorator < SimpleDelegator
     page.require_parliamentary_group? && parliamentary_group_name.blank? && parliamentary_group_item.blank?
   end
 
+  def merged_then_deleted
+    data&.merged_then_deleted.split.map { |item| item.split('/').last }
+  end
+
   def person_matches?
-    person_item.present? && [data&.person, data&.merged_then_deleted].include?(person_item)
+    person_item.present? && ([data&.person] + merged_then_deleted).include?(person_item)
   end
 end

--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -25,7 +25,7 @@ class RetrievePositionData < ServiceBase
 
   def query
     <<~SPARQL
-      SELECT DISTINCT ?person ?merged_then_deleted ?revision ?position ?start_of_term ?start_date ?term ?group ?district
+      SELECT DISTINCT ?person (GROUP_CONCAT(?merged_then_deleted) AS ?merged_then_deleted) ?revision ?position ?start_of_term ?start_date ?term ?group ?district
       WHERE {
         %<person_bind>s
         BIND(wd:%<parliamentary_term_item>s AS ?page_term)
@@ -46,6 +46,7 @@ class RetrievePositionData < ServiceBase
           ?start_of_page_term <= ?start_date
         )
       }
+      GROUP BY ?person ?revision ?position ?start_of_term ?start_date ?term ?group ?district
     SPARQL
   end
 

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -116,9 +116,13 @@ class StatementClassifier
     )
   end
 
+  def merged_then_deleted(data)
+    data.merged_then_deleted.split.map { |item| item.split('/').last }
+  end
+
   def matching_position_held_data(statement)
     position_held_data.select do |data|
-      [data.person, data.merged_then_deleted].include?(statement.person_item)
+      ([data.person] + merged_then_deleted(data)).include?(statement.person_item)
     end
   end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe StatementClassifier, type: :service do
 
     let(:wikidata_data) do
       { person: 'Q1',
-        merged_then_deleted: nil,
+        merged_then_deleted: '',
         term: 'Q2',
         start_of_term: '2018-01-01',
         start_date: '2018-01-01',
@@ -257,7 +257,7 @@ RSpec.describe StatementClassifier, type: :service do
       # so the statement will be in "done".
       let(:wikidata_data) do
         { person: 'Q200',
-          merged_then_deleted: 'Q1',
+          merged_then_deleted: 'http://www.wikidata.org/entity/Q1111 http://www.wikidata.org/entity/Q1',
           term: 'Q2',
           start_of_term: '2018-01-01',
           start_date: '2018-01-01',


### PR DESCRIPTION
When multiple items have been `merged_then_deleted` into another item the same position will appear multiple times in the search results, once for each item that was deleted and merged into the master item.

This changes the SPARQL query to get `?merged_then_deleted` as a space-separated list, so each position should only appear in the query results once.

Fixes #153 