### PR TITLE
Fix 'Create person' button for the API proxy

### DIFF
--- a/app/controllers/media_wiki_api_controller.rb
+++ b/app/controllers/media_wiki_api_controller.rb
@@ -39,6 +39,7 @@ class MediaWikiApiController < ApplicationController
     'wbsetreference' => true,
     'wbsetqualifier' => true,
     'wbcreateclaim' => true,
+    'wbeditentity' => true
   }
 
   def api_data_for_action(action)


### PR DESCRIPTION
Running the Vue.js app locally we can't get past the 'Create person' reconciliation step as the API method requires a token.