### PR TITLE
Link to Wikidata when running app locally

### DIFF
--- a/app/javascript/components/wikilink.html
+++ b/app/javascript/components/wikilink.html
@@ -1,5 +1,5 @@
 <span>
-  <a v-if="id" :href="'/wiki/' + id">
+  <a v-if="id" :href="wikidata_site + '/wiki/' + id">
     <slot></slot>
   </a>
   <slot v-else></slot>

--- a/app/javascript/components/wikilink.js
+++ b/app/javascript/components/wikilink.js
@@ -1,5 +1,14 @@
 import template from './wikilink.html'
 
 export default template({
-  props: ['id', 'name']
+  props: ['id', 'name'],
+  computed: {
+    wikidata_site: function () {
+      if (typeof WIKIDATA_SITE !== 'undefined') {
+        return 'https://' + WIKIDATA_SITE
+      } else {
+        return ''
+      }
+    }
+  }
 })

--- a/app/views/general/frontend.html.erb
+++ b/app/views/general/frontend.html.erb
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Verification Pages</title>
     <%= javascript_tag "CURRENT_PAGE_TITLE = '#{@page.title}'" %>
+    <%= javascript_tag "WIKIDATA_SITE = '#{ENV['WIKIDATA_SITE']}'" %>
     <%= javascript_pack_tag 'verification_tool' %>
     <%= stylesheet_link_tag 'wikidata_styles' %>
   </head>


### PR DESCRIPTION
Instead of linking to broken pages such as `https://verification.test/wiki/Q1` this uses the `WIKIDATA_SITE` environment variable to correctly link to the Wikidata site being used locally.