### PR TITLE
[#175] Rework how references are added to statements

### DIFF
--- a/app/controllers/media_wiki_api_controller.rb
+++ b/app/controllers/media_wiki_api_controller.rb
@@ -50,7 +50,7 @@ class MediaWikiApiController < ApplicationController
     elsif action == 'query'
       params.permit(:prop, :titles)
     elsif action == 'wbsetreference'
-      params.permit(:statement, :snaks, :baserevid, :summary)
+      params.permit(:statement, :snaks, :baserevid, :reference, :summary)
     elsif action == 'wbsetqualifier'
       params.permit(:claim, :property, :value, :baserevisionid, :snaktype, :summary)
     elsif action == 'wbcreateclaim'

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -83,6 +83,10 @@ class StatementDecorator < SimpleDelegator
     [ 'party' ]
   end
 
+  def verified_on
+    latest_verification.try(:created_at).try(:to_date)
+  end
+
   private
 
   attr_reader :matching_position_held_data

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -35,6 +35,10 @@ export default template({
         value: this.page.reference_url, type: 'string'
       }
 
+      references[wikidataClient.getPropertyID('reference retrieved')] = {
+        value: this.statement.verified_on, type: 'time'
+      }
+
       if (this.statement.parliamentary_group_item) {
         qualifiers[wikidataClient.getPropertyID('parliamentary group')] =
           this.statement.parliamentary_group_item;

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -19,7 +19,6 @@ export default template({
           updateData = {
             property: wikidataClient.getPropertyID('position held'),
             object: this.page.position_held_item,
-            referenceURL: this.page.reference_url,
             references: references,
             qualifiers: qualifiers,
           }, that = this;

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -14,11 +14,13 @@ export default template({
     updatePositionHeld: function () {
       var personItem = this.statement.person_item,
           item = wikidataClient.item(personItem),
+          references = {},
           qualifiers = {},
           updateData = {
             property: wikidataClient.getPropertyID('position held'),
             object: this.page.position_held_item,
             referenceURL: this.page.reference_url,
+            references: references,
             qualifiers: qualifiers,
           }, that = this;
 
@@ -28,6 +30,10 @@ export default template({
         // Make sure there's a $ in the claim ID separating the item
         // ID from the UUID, otherwise we get invalid GUID errors.
         updateData.statement = this.statement.statement_uuid.replace(/^(Q\d+)[^\d]/, '$1$');
+      }
+
+      references[wikidataClient.getPropertyID('reference URL')] = {
+        value: this.page.reference_url, type: 'string'
       }
 
       if (this.statement.parliamentary_group_item) {

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -58,10 +58,24 @@ function buildReferenceSnaks (references) {
   var snaks = {}
 
   Object.keys(references).forEach(function (property) {
+    var datavalue = references[property]
+    if (!datavalue.value) return
+
+    if (datavalue.type === 'time') {
+      datavalue.value = {
+        after: 0,
+        before: 0,
+        calendarmodel: 'http://www.wikidata.org/entity/Q1985727',
+        precision: 11,
+        time: datavalue.value,
+        timezone: 0
+      }
+    }
+
     snaks[property] = [{
       snaktype: 'value',
       property: property,
-      datavalue: references[property]
+      datavalue: datavalue
     }]
   })
 

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -385,6 +385,7 @@ var wikidata = function(spec) {
     return {
       'www.wikidata.org': {
         'reference URL': 'P854',
+        'reference retrieved': 'P813',
         'occupation': 'P106',
         'parliamentary group': 'P4100',
         'electoral district': 'P768',
@@ -393,6 +394,7 @@ var wikidata = function(spec) {
       },
       'test.wikidata.org': {
         'reference URL': 'P43659',
+        'reference retrieved': 'P388',
         'occupation': 'P70554',
         'parliamentary group': 'P70557',
         'electoral district': 'P70558',
@@ -405,6 +407,7 @@ var wikidata = function(spec) {
         // server for this information, since it must know which server
         // it's proxying to..)
         'reference URL': 'P43659',
+        'reference retrieved': 'P388',
         'occupation': 'P70554',
         'parliamentary group': 'P70557',
         'electoral district': 'P70558',

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -24,6 +24,24 @@ function getQualifiersFromAPIClaims(apiClaims, property) {
   return apiClaims[property][0].qualifiers;
 }
 
+function getReferencesFromAPIClaims(apiClaims, property) {
+  if (!apiClaims[property]) {
+    return [];
+  }
+  return apiClaims[property][0].references;
+}
+
+function getReferenceForURLFromAPIClaims (references, referenceURLProp, referenceURL) {
+  if (!references || !referenceURL) return
+  return references.find(function (r) {
+    var snak = r.snaks[referenceURLProp].find(function (s) {
+      return s.datatype === 'url' && s.datavalue.value === referenceURL.value
+    })
+    console.log(snak)
+    return typeof snak !== 'undefined'
+  })
+}
+
 function checkForError(data) {
   // Weirdly, errors like bad CSRF tokens still return success
   // rather than going to the fail handlers, so we use this even
@@ -36,19 +54,18 @@ function checkForError(data) {
   }
 }
 
-function getReferenceSnaks(referenceURLProp, referenceURL) {
-  var snaks = {};
-  snaks[referenceURLProp] = [
-    {
+function buildReferenceSnaks (references) {
+  var snaks = {}
+
+  Object.keys(references).forEach(function (property) {
+    snaks[property] = [{
       snaktype: 'value',
-      property: referenceURLProp,
-      datavalue: {
-        type: 'string',
-        value: referenceURL,
-      }
-    }
-  ];
-  return JSON.stringify(snaks);
+      property: property,
+      datavalue: references[property]
+    }]
+  })
+
+  return JSON.stringify(snaks)
 }
 
 function getNewQualifiers(qualifiersFromAPI, wantedQualifiers) {
@@ -96,21 +113,6 @@ function getNewQualifiers(qualifiersFromAPI, wantedQualifiers) {
 var wikidataItem = function(spec) {
   var that = {}, wikidata = spec.wikidata, item = spec.item, lastRevisionID = null,
       my = {};
-
-  my.alreadyHasReferenceURL = function(referencesFromAPI, wantedReference) {
-    var i, j, values, referenceFromAPI;
-    referencesFromAPI = referencesFromAPI || [];
-    for (i = 0; i < referencesFromAPI.length; ++i) {
-      referenceFromAPI = referencesFromAPI[i];
-      values = referenceFromAPI.snaks[wikidata.getPropertyID('reference URL')] || [];
-      for (j = 0; j < values.length; ++j) {
-        if (values[j].datatype == 'string' && values[j].datavalue.value == wantedReference) {
-          return true;
-        }
-      }
-    }
-    return false;
-  };
 
   my.ajaxSetQualifier = function(qualifierDetails) {
     return wikidata.ajaxAPI(true, 'wbsetqualifier', {
@@ -162,6 +164,36 @@ var wikidataItem = function(spec) {
     }
   };
 
+  my.createReferences = function (claims, data) {
+    var referenceURLProp = wikidata.getPropertyID('reference URL')
+    var referenceURL = data.references[referenceURLProp]
+
+    var currentReference = getReferenceForURLFromAPIClaims(
+      getReferencesFromAPIClaims(claims, data.property),
+      referenceURLProp,
+      referenceURL
+    )
+
+    console.log('There are ' + Object.keys(data.references).length + ' references to create....');
+
+    if (Object.keys(data.references).length > 0) {
+      var data = {
+        statement: data.statement,
+        snaks: buildReferenceSnaks(data.references),
+        baserevid: lastRevisionID,
+        summary: wikidata.summary()
+      }
+
+      if (currentReference) {
+        data['reference'] = currentReference.hash
+      }
+
+      return wikidata.ajaxAPI(true, 'wbsetreference', data)
+    } else {
+      return Promise.resolve(null)
+    }
+  }
+
   my.createBareClaimDeferred = function(claimData) {
     // TODO the data we've been passed (indicating there wasn't an
     // existing statement to update) might be quite stale,
@@ -206,28 +238,13 @@ var wikidataItem = function(spec) {
           );
         }
 
-      console.log('Looks good to update these qualifiers:', newQualifiers);
-      return my.createQualifiers(newClaim, newQualifiers).then(function() {
-        // Set a reference URL:
-        if (my.alreadyHasReferenceURL(
-          data.claims[newClaim.property][0].references,
-          newClaim.referenceURL)) {
-          return Promise.resolve(null);
-        } else {
-          // We should set the referenceURL:
-          return wikidata.ajaxAPI(true, 'wbsetreference', {
-            statement: newClaim.statement,
-            snaks: getReferenceSnaks(
-              wikidata.getPropertyID('reference URL'),
-              newClaim.referenceURL
-            ),
-            baserevid: lastRevisionID,
-            summary: wikidata.summary()
-          });
-        }
-      });
-    });
-  };
+      console.log('Looks good to update these qualifiers:', newQualifiers)
+
+      return my.createQualifiers(newClaim, newQualifiers).then(function (foo) {
+        return my.createReferences(data.claims, newClaim)
+      })
+    })
+  }
 
   that.updateOrCreateClaim = function(baseRevisionID, claimData) {
     lastRevisionID = baseRevisionID;

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -1,19 +1,29 @@
-json.statements @classifier.to_a,
-  :type,
-  :transaction_id,
-  :person_item,
-  :person_revision,
-  :statement_uuid,
-  :parliamentary_group_item,
-  :electoral_district_item,
-  :parliamentary_term_item,
-  :created_at,
-  :updated_at,
-  :person_name,
-  :parliamentary_group_name,
-  :electoral_district_name,
-  :problems,
-  :reconciliations
+json.statements @classifier.to_a do |statement|
+  json.call(
+    statement,
+    :type,
+    :transaction_id,
+    :person_item,
+    :person_revision,
+    :statement_uuid,
+    :parliamentary_group_item,
+    :electoral_district_item,
+    :parliamentary_term_item,
+    :created_at,
+    :updated_at,
+    :person_name,
+    :parliamentary_group_name,
+    :electoral_district_name,
+    :problems,
+    :reconciliations
+  )
+
+  if statement.verified_on
+    json.verified_on "+#{statement.verified_on.iso8601}"
+  else
+    json.verified_on nil
+  end
+end
 
 json.page @classifier.page, :reference_url, :position_held_item
 

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -219,6 +219,28 @@ RSpec.describe StatementDecorator, type: :decorator do
     end
   end
 
+  describe '#verified_on' do
+    subject { statement.verified_on }
+
+    context 'with verification' do
+      let(:time) { Time.utc(2018, 1, 1, 13, 45) }
+      before do
+        allow(statement).to receive(:latest_verification).and_return(
+          Verification.new(created_at: time)
+        )
+      end
+
+      it { is_expected.to eq Date.new(2018, 1, 1) }
+    end
+
+    context 'without verification' do
+      before do
+        allow(statement).to receive(:latest_verification).and_return(nil)
+      end
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#person_matches?' do
     let(:matching_position_held_data) { [] }
     context 'with no matching position held data' do


### PR DESCRIPTION
### Relevant issue(s)

Connects to: #175 - but not closes as we might want to add more references values too.

### What does this do?

Makes it possible to add more than just a reference URL to statements. For now I have just added the date the reference was retrieved but it should be trivial now to add others

### Why was this needed?

Better an more complete data on Wikidata.

### Implementation notes

This was hard to implement and I headed down the wrong rabbit hole a number of times. The important thing to note is API docs [1] mentions we can send through the previous reference hash to update the old reference. This is what I've now done but originally weren't doing this. I had thought we could just not send the values we didn't want updating (ala the original code and how qualifiers are handled), due to this being hard to test I spent a long time going the wrong direction. 

[1] https://www.mediawiki.org/wiki/Wikibase/API#wbsetreference

