### PR TITLE
[#221] Render all statements in a table

### DIFF
--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -47,6 +47,7 @@
   </div>
   <div v-if="loaded && currentStatements.length > 0">
     <table class="verification-tool__table">
+      <tbody v-for="statement in currentStatements">
       <tr>
         <td>
           <span class="verification-tool__table__cell-label">Subject</span>
@@ -72,13 +73,14 @@
       <tr>
         <td colspan="5" v-bind:class="'verification-tool__statement-controls verification-tool__statement-controls--' + statement.type">
           <span v-if="!submitting">
-            <component v-bind:is="currentView" :statement="statement" :page="page" :country="country"></component>
+            <ActionWrapper :statement="statement" :page="page" :country="country"></ActionWrapper>
           </span>
           <span v-else>
             Submitting...
           </span>
         </td>
       </tr>
+      </tbody>
     </table>
   </div>
   <div v-if="!loaded" class="verification-tool__blank-slate">

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -63,12 +63,7 @@
       </tr>
       <tr>
         <td colspan="5" v-bind:class="'verification-tool__statement-controls verification-tool__statement-controls--' + statement.type">
-          <span v-if="!submitting">
-            <ActionWrapper :statement="statement" :page="page" :country="country"></ActionWrapper>
-          </span>
-          <span v-else>
-            Submitting...
-          </span>
+          <ActionWrapper :statement="statement" :page="page" :country="country"></ActionWrapper>
         </td>
       </tr>
       </tbody>

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -27,15 +27,6 @@
         </option>
       </select>
     </div>
-    <div class="verification-tool__controls__group" style="float: right;">
-      <button v-on:click="prevStatement()" class="mw-ui-button">Previous</button>
-      <button v-on:click="nextStatement()" class="mw-ui-button">Next</button>
-    </div>
-    <div class="verification-tool__controls__group" style="float: right;">
-      <label for="displayIndex">Statement</label>
-      <input v-model:number="displayIndex" type="number" style="width: 4em;" id="displayIndex">
-      of {{ currentStatements.length }}
-    </div>
   </div>
   <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
     <div v-if="displayType === 'all'">

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -1,15 +1,12 @@
+import Vue from 'vue'
 import ENV from './env'
 import Axios from 'axios'
 import wikidataClient from './wikiapi'
 import template from './app.html?style=./app.css'
 
-import verifiableComponent from './components/verifiable'
-import unverifiableComponent from './components/unverifiable'
-import reconcilableComponent from './components/reconcilable'
-import actionableComponent from './components/actionable'
-import manuallyActionableComponent from './components/manually_actionable'
-import doneComponent from './components/done'
-import revertedComponent from './components/reverted'
+import actionWrapper from './components/action_wrapper'
+
+Vue.component('ActionWrapper', actionWrapper)
 
 export default template({
   data () {
@@ -33,17 +30,6 @@ export default template({
     }
   },
   computed: {
-    currentView: function () {
-      switch (this.statement.type) {
-        case 'verifiable': return verifiableComponent
-        case 'unverifiable': return unverifiableComponent
-        case 'reconcilable': return reconcilableComponent
-        case 'actionable': return actionableComponent
-        case 'manually_actionable': return manuallyActionableComponent
-        case 'done': return doneComponent
-        case 'reverted': return revertedComponent
-      }
-    },
     statement: function () {
       const statement = this.currentStatements[this.statementIndex]
       if (statement) return statement

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -12,7 +12,6 @@ export default template({
   data () {
     return {
       loaded: false,
-      submitting: false,
       statements: [],
       displayType: 'all',
       page: null
@@ -29,8 +28,7 @@ export default template({
   },
   created: function () {
     this.loadStatements()
-    this.$on('statement-update', requestFunction => {
-      this.submitting = true
+    this.$on('statement-update', (requestFunction, cb) => {
       requestFunction().then(response => {
         if (response.data.statements.length > 1) {
           throw 'Response has too many statements. We don\'t know which one to update'
@@ -40,8 +38,7 @@ export default template({
           return s.transaction_id === newStatement.transaction_id
         })
         this.statements.splice(index, 1, newStatement)
-        this.submitting = false
-      })
+      }).then(cb)
     })
   },
   methods: {

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -14,28 +14,11 @@ export default template({
       loaded: false,
       submitting: false,
       statements: [],
-      statementIndex: 0,
       displayType: 'all',
       page: null
     }
   },
-  watch: {
-    statementIndex: function (newVal) {
-      if (newVal < 0) {
-        this.statementIndex = this.currentStatements.length - 1
-      } else {
-        this.statementIndex = newVal % this.currentStatements.length
-      }
-      this.$emit('statement-changed')
-    }
-  },
   computed: {
-    statement: function () {
-      const statement = this.currentStatements[this.statementIndex]
-      if (statement) return statement
-      this.statementIndex = this.currentStatements.length - 1
-      return this.currentStatements[this.statementIndex]
-    },
     currentStatements: function () {
       if (this.displayType !== 'all') {
         return this.statements.filter(s => s.type === this.displayType)
@@ -43,10 +26,6 @@ export default template({
         return this.statements
       }
     },
-    displayIndex: {
-      get: function () { return this.statementIndex + 1 },
-      set: function (val) { this.statementIndex = val - 1 }
-    }
   },
   created: function () {
     this.loadStatements()
@@ -76,12 +55,6 @@ export default template({
       }).then(() => {
         this.loaded = true
       })
-    },
-    prevStatement: function () {
-      this.statementIndex = this.statementIndex - 1
-    },
-    nextStatement: function () {
-      this.statementIndex = this.statementIndex + 1
     },
     countStatementsOfType: function (type) {
       if (type !== 'all') {

--- a/app/javascript/components/action_wrapper.html
+++ b/app/javascript/components/action_wrapper.html
@@ -1,1 +1,6 @@
-<span v-bind:is="currentView" :statement="statement" :page="page" :country="country"></span>
+<span v-if="!submitting">
+  <span v-bind:is="currentView" :statement="statement" :page="page" :country="country"></span>
+</span>
+<span v-else>
+  Submitting...
+</span>

--- a/app/javascript/components/action_wrapper.html
+++ b/app/javascript/components/action_wrapper.html
@@ -1,0 +1,1 @@
+<span v-bind:is="currentView" :statement="statement" :page="page" :country="country"></span>

--- a/app/javascript/components/action_wrapper.js
+++ b/app/javascript/components/action_wrapper.js
@@ -9,7 +9,11 @@ import doneComponent from './done'
 import revertedComponent from './reverted'
 
 export default template({
-  data () { return { } },
+  data () {
+    return {
+      submitting: false,
+    }
+  },
   props: ['statement', 'page', 'country'],
   computed: {
     currentView: function () {
@@ -26,7 +30,10 @@ export default template({
   },
   created: function () {
     this.$on('statement-update', requestFunction => {
-      this.$parent.$emit('statement-update', requestFunction)
+      this.submitting = true
+      this.$parent.$emit('statement-update', requestFunction, () => {
+        this.submitting = false
+      })
     })
   }
 })

--- a/app/javascript/components/action_wrapper.js
+++ b/app/javascript/components/action_wrapper.js
@@ -1,0 +1,27 @@
+import template from './action_wrapper.html'
+
+import verifiableComponent from './verifiable'
+import unverifiableComponent from './unverifiable'
+import reconcilableComponent from './reconcilable'
+import actionableComponent from './actionable'
+import manuallyActionableComponent from './manually_actionable'
+import doneComponent from './done'
+import revertedComponent from './reverted'
+
+export default template({
+  data () { return { } },
+  props: ['statement', 'page', 'country'],
+  computed: {
+    currentView: function () {
+      switch (this.statement.type) {
+        case 'verifiable': return verifiableComponent
+        case 'unverifiable': return unverifiableComponent
+        case 'reconcilable': return reconcilableComponent
+        case 'actionable': return actionableComponent
+        case 'manually_actionable': return manuallyActionableComponent
+        case 'done': return doneComponent
+        case 'reverted': return revertedComponent
+      }
+    }
+  }
+})

--- a/app/javascript/components/action_wrapper.js
+++ b/app/javascript/components/action_wrapper.js
@@ -23,5 +23,10 @@ export default template({
         case 'reverted': return revertedComponent
       }
     }
+  },
+  created: function () {
+    this.$on('statement-update', requestFunction => {
+      this.$parent.$emit('statement-update', requestFunction)
+    })
   }
 })

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -9,7 +9,7 @@ export default template({
     finished: false,
     updateError: null,
   } },
-  props: ['statement', 'page'],
+  props: ['statement', 'page', 'country'],
   methods: {
     updatePositionHeld: function () {
       var personItem = this.statement.person_item,

--- a/app/javascript/components/done.js
+++ b/app/javascript/components/done.js
@@ -1,5 +1,6 @@
 import template from './done.html'
 
 export default template({
-  data () { return {} }
+  data () { return {} },
+  props: ['statement', 'page', 'country']
 })

--- a/app/javascript/components/manually_actionable.js
+++ b/app/javascript/components/manually_actionable.js
@@ -2,5 +2,5 @@ import template from './manually_actionable.html'
 
 export default template({
   data () { return {} },
-  props: ['statement']
+  props: ['statement', 'page', 'country']
 })

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -10,7 +10,7 @@ export default template({
     searchResults: null,
     searchResourceType: null
   } },
-  props: ['statement', 'country'],
+  props: ['statement', 'page', 'country'],
   created: function () {
     this.$parent.$on('statement-changed', () => {
       this.searchResultsLoading = false

--- a/app/javascript/components/reverted.js
+++ b/app/javascript/components/reverted.js
@@ -1,5 +1,6 @@
 import template from './reverted.html'
 
 export default template({
-  data () { return {} }
+  data () { return {} },
+  props: ['statement', 'page', 'country']
 })

--- a/app/javascript/components/unverifiable.js
+++ b/app/javascript/components/unverifiable.js
@@ -1,5 +1,6 @@
 import template from './unverifiable.html'
 
 export default template({
-  data () { return {} }
+  data () { return {} },
+  props: ['statement', 'page', 'country']
 })

--- a/app/javascript/components/verifiable.js
+++ b/app/javascript/components/verifiable.js
@@ -9,7 +9,7 @@ export default template({
     changingName: false,
     newName: null
   } },
-  props: ['statement', 'page'],
+  props: ['statement', 'page', 'country'],
   methods: {
     submitStatement: function (status) {
       if (this.newName && Levenshtein(this.newName, this.statement.person_name) > 5) {


### PR DESCRIPTION
Fixes #221 

Work done while pairing with @zarino 

This PR changes how we are rendering the statements so everything can be seen at once. We've removed the pagination but filtering and actions do still work through a new action wrapper component. This was required to allow us to render different statement types at once and allowed us to have the submitting loading state affect only one statement at a time.