### PR TITLE
[#217] Allow sorting by party then last name, and district then last name

### DIFF
--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -27,6 +27,14 @@
         </option>
       </select>
     </div>
+    <div class="verification-tool__controls__group">
+      <label for="sortBy">Sort by</label>
+      <select v-model="sortBy" id="sortBy">
+        <option value="lastName">Last name</option>
+        <option value="parliamentaryGroup">Parliamentary group</option>
+        <option value="district">District</option>
+      </select>
+    </div>
   </div>
   <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
     <div v-if="displayType === 'all'">

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -15,6 +15,7 @@ export default template({
       loaded: false,
       statements: [],
       displayType: 'all',
+      sortBy: 'lastName',
       page: null
     }
   },
@@ -65,9 +66,16 @@ export default template({
       }
     },
     sortStatements: function (statements) {
+      var prefix
+
+      switch (this.sortBy) {
+        case 'parliamentaryGroup': prefix = 'parliamentary_group_name'; break
+        case 'district': prefix = 'electoral_district_name'; break
+      }
+
       return statements.sort(function (a, b) {
-        const nameA = parseFullName(a.person_name).last
-        const nameB = parseFullName(b.person_name).last
+        const nameA = (a[prefix] || '') + parseFullName(a.person_name).last
+        const nameB = (b[prefix] || '') + parseFullName(b.person_name).last
         return nameA.localeCompare(nameB)
       })
     }


### PR DESCRIPTION
Fixes #217.

Work done while pairing with @zarino 

Default sorting is still by last name but now we can also sort by party and district and then last name.

Re-rendering takes a moment to happen but the lag seems acceptable - we might need to revisit and implement a loading spinner later.

![screen shot 2018-07-09 at 11 59 33](https://user-images.githubusercontent.com/5426/42447079-1a25717e-8368-11e8-8669-16d0d8ae9697.png)
