### PR TITLE
[#245] Fix Wikidata error adding references

### DIFF
--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -19,7 +19,7 @@ json.statements @classifier.to_a do |statement|
   )
 
   if statement.verified_on
-    json.verified_on "+#{statement.verified_on.iso8601}"
+    json.verified_on "+#{statement.verified_on.iso8601}T00:00:00Z"
   else
     json.verified_on nil
   end


### PR DESCRIPTION
We require the timestamp part of the verified_on attribute otherwise we get `Data value corrupt: $timestamp must resemble ISO 8601` error.