### PR TITLE
[#180] Auto action statements

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -16,7 +16,14 @@ class StatementsController < FrontendController
 
   def show
     statement = Statement.find_by!(transaction_id: params.fetch(:id))
-    statement.record_actioned! if params[:force_type] == 'done'
+
+    case params[:force_type]
+    when 'done'
+      statement.record_actioned!
+    when 'manually_actionable'
+      statement.report_error!(params[:error_message])
+    end
+
     respond_with(statement)
   end
 end

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -27,7 +27,8 @@ class StatementDecorator < SimpleDelegator
     electoral_district_problems +
       parliamentary_group_problems +
       start_date_before_term_problems +
-      multiple_statement_problems
+      multiple_statement_problems +
+      reported_problems
   end
 
   def start_date_before_term_problems
@@ -49,6 +50,11 @@ class StatementDecorator < SimpleDelegator
   def multiple_statement_problems
     return [] unless matching_position_held_data.length > 1
     [ "There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier" ]
+  end
+
+  def reported_problems
+    return [] unless reported_at
+    [ error_reported ]
   end
 
   def unverifiable?

--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -103,6 +103,7 @@ $color_pale_grey: #eee;
     background: $color_pale_blue;
 }
 
+.verification-tool__statement-controls--error,
 .verification-tool__statement-controls--unverifiable {
     border-color: $color_mid_red;
     background-color: $color_pale_red;

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -70,9 +70,7 @@
         </td>
       </tr>
       <tr>
-        <td colspan="5" v-bind:class="'verification-tool__statement-controls verification-tool__statement-controls--' + statement.type">
-          <ActionWrapper :statement="statement" :page="page" :country="country"></ActionWrapper>
-        </td>
+        <ActionWrapper :statement="statement" :page="page" :country="country"></ActionWrapper>
       </tr>
       </tbody>
     </table>

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -31,10 +31,12 @@ export default template({
         if (response.data.statements.length > 1) {
           throw 'Response has too many statements. We don\'t know which one to update'
         }
-        const newStatement = response.data.statements[0]
+        var newStatement = response.data.statements[0]
         const index = this.statements.findIndex(s => {
           return s.transaction_id === newStatement.transaction_id
         })
+        const previousType = this.statements[index].type
+        newStatement.previousType = previousType
         this.statements.splice(index, 1, newStatement)
       }).then(cb)
     })

--- a/app/javascript/components/action_wrapper.html
+++ b/app/javascript/components/action_wrapper.html
@@ -1,6 +1,8 @@
-<span v-if="!submitting">
-  <span v-bind:is="currentView" :statement="statement" :page="page" :country="country"></span>
-</span>
-<span v-else>
-  Submitting...
-</span>
+<td colspan="5" v-bind:class="'verification-tool__statement-controls verification-tool__statement-controls--' + stylingClass">
+  <span v-if="!submitting">
+    <span v-bind:is="currentView" :statement="statement" :page="page" :country="country"></span>
+  </span>
+  <span v-else>
+    Submitting...
+  </span>
+</td>

--- a/app/javascript/components/action_wrapper.js
+++ b/app/javascript/components/action_wrapper.js
@@ -34,8 +34,8 @@ export default template({
     }
   },
   created: function () {
-    this.$on('statement-error', () => {
-      this.error = true
+    this.$on('statement-error', (state) => {
+      this.error = state
     })
 
     this.$on('statement-update', requestFunction => {

--- a/app/javascript/components/action_wrapper.js
+++ b/app/javascript/components/action_wrapper.js
@@ -12,6 +12,7 @@ export default template({
   data () {
     return {
       submitting: false,
+      error: false
     }
   },
   props: ['statement', 'page', 'country'],
@@ -26,9 +27,17 @@ export default template({
         case 'done': return doneComponent
         case 'reverted': return revertedComponent
       }
+    },
+    stylingClass: function () {
+      if (this.error) { return 'error' }
+      return this.statement.type
     }
   },
   created: function () {
+    this.$on('statement-error', () => {
+      this.error = true
+    })
+
     this.$on('statement-update', requestFunction => {
       this.submitting = true
       this.$parent.$emit('statement-update', requestFunction, () => {

--- a/app/javascript/components/actionable.html
+++ b/app/javascript/components/actionable.html
@@ -1,41 +1,27 @@
 <div>
-  <p>
-    You can set the following 'position held' information for statement for
-    <wikilink :id="statement.person_item">{{ statement.person_name }}</wikilink>
-    now:
-  </p>
-
-  <ul>
-    <li v-if="statement.parliamentary_group_item">'parliamentary group' qualifier:
-      <wikilink :id="statement.parliamentary_group_item">
-        {{ statement.parliamentary_group_name }}
-        ({{ statement.parliamentary_group_item }})
-      </wikilink>
-    </li>
-    <li v-if="statement.electoral_district_item">'electoral district' qualifier:
-      <wikilink :id="statement.electoral_district_item">
-        {{ statement.electoral_district_name }}
-        ({{ statement.electoral_district_item }})
-      </wikilink>
-    </li>
-    <li>'parliamentary term' qualifier:
-      <wikilink :id="statement.parliamentary_term_item">
-        {{ statement.parliamentary_term_item }}
-      </wikilink>
-    </li>
-    <li>'reference URL' qualifier:
-      <a target="_blank" rel="noopener nofollow" class="external free" :href="page.reference_url">{{ page.reference_url }}</a>
-    </li>
-  </ul>
-
   <div v-if="!updating && !finished">
-    <button v-on:click="updatePositionHeld()">Create or update 'position held'</button>
+    <p>
+      You can update Wikidata with the following 'position held' information for statement for
+      <wikilink :id="statement.person_item">{{ statement.person_name }}</wikilink>
+      now:
+    </p>
+
+    <StatementChangeSummary :statement="statement" :page="page"></StatementChangeSummary>
+
+    <p>
+      <button v-on:click="updatePositionHeld()" class="mw-ui-button mw-ui-progressive">Create or update 'position held'</button>
+    </p>
   </div>
   <div v-else-if="updating">
     Updating...
   </div>
   <div v-else-if="!updating && finished && updateError">
     There was an error when updating: {{ updateError }}
+
+    <details>
+      <summary>Changes we attempted</summary>
+      <StatementChangeSummary :statement="statement" :page="page"></StatementChangeSummary>
+    </details>
   </div>
   <div v-else>
     Successfully updated!

--- a/app/javascript/components/actionable.html
+++ b/app/javascript/components/actionable.html
@@ -16,12 +16,18 @@
     Updating...
   </div>
   <div v-else-if="!updating && finished && updateError">
-    There was an error when updating: {{ updateError }}
+    <p>
+      Oops we couldn’t make that change right now: {{ updateError }}
+    </p>
 
     <details>
       <summary>Changes we attempted</summary>
       <StatementChangeSummary :statement="statement" :page="page"></StatementChangeSummary>
     </details>
+
+    <p>
+      <button v-on:click="updatePositionHeld()" class="mw-ui-button">Retry</button>
+    </p>
   </div>
   <div v-else>
     Successfully updated!

--- a/app/javascript/components/actionable.html
+++ b/app/javascript/components/actionable.html
@@ -26,6 +26,7 @@
     </details>
 
     <p>
+      <button v-on:click="reportStatementError()" class="mw-ui-button mw-ui-progressive">Report this statement</button>
       <button v-on:click="updatePositionHeld()" class="mw-ui-button">Retry</button>
     </p>
   </div>

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -10,6 +10,11 @@ export default template({
     updateError: null,
   } },
   props: ['statement', 'page', 'country'],
+  created: function () {
+    if (['verifiable', 'reconcilable'].indexOf(this.statement.previousType) !== -1) {
+      this.updatePositionHeld()
+    }
+  },
   methods: {
     updatePositionHeld: function () {
       var personItem = this.statement.person_item,

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -61,6 +61,8 @@ export default template({
           this.statement.parliamentary_term_item;
       }
 
+      this.$parent.$emit('statement-error', false)
+
       item.latestRevision().then(function(lastRevisionID) {
         return item.updateOrCreateClaim(lastRevisionID, updateData);
       }).then(function (result) {
@@ -80,7 +82,7 @@ export default template({
         that.updating = false;
         that.finished = true;
         that.updateError = error.message;
-        that.$parent.$emit('statement-error')
+        that.$parent.$emit('statement-error', true)
       });
     }
   }

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -80,6 +80,7 @@ export default template({
         that.updating = false;
         that.finished = true;
         that.updateError = error.message;
+        that.$parent.$emit('statement-error')
       });
     }
   }

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -1,7 +1,11 @@
+import Vue from 'vue'
 import ENV from '../env'
 import Axios from 'axios'
 import wikidataClient from '../wikiapi'
 import template from './actionable.html'
+import StatementChangeSummary from './statement_change_summary'
+
+Vue.component('StatementChangeSummary', StatementChangeSummary)
 
 export default template({
   data () { return {

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -84,6 +84,18 @@ export default template({
         that.updateError = error.message;
         that.$parent.$emit('statement-error', true)
       });
+    },
+    reportStatementError: function () {
+      this.$parent.$emit('statement-error', false)
+      this.$parent.$emit('statement-update', () => {
+        return Axios.get(
+          ENV.url + '/statements/' + this.statement.transaction_id + '.json',
+          { params: {
+            force_type: 'manually_actionable',
+            error_message: this.updateError
+          } }
+        )
+      })
     }
   }
 })

--- a/app/javascript/components/statement_change_summary.html
+++ b/app/javascript/components/statement_change_summary.html
@@ -1,0 +1,25 @@
+<ul>
+  <li v-if="statement.parliamentary_group_item">'parliamentary group' qualifier:
+    <wikilink :id="statement.parliamentary_group_item">
+      {{ statement.parliamentary_group_name }}
+      ({{ statement.parliamentary_group_item }})
+    </wikilink>
+  </li>
+  <li v-if="statement.electoral_district_item">'electoral district' qualifier:
+    <wikilink :id="statement.electoral_district_item">
+      {{ statement.electoral_district_name }}
+      ({{ statement.electoral_district_item }})
+    </wikilink>
+  </li>
+  <li>'parliamentary term' qualifier:
+    <wikilink :id="statement.parliamentary_term_item">
+      {{ statement.parliamentary_term_item }}
+    </wikilink>
+  </li>
+  <li>'reference URL' qualifier:
+    <a target="_blank" rel="noopener nofollow" class="external free" :href="page.reference_url">{{ page.reference_url }}</a>
+  </li>
+  <li>'reference retrieved' qualifier:
+    {{ statement.verified_on }}
+  </li>
+</ul>

--- a/app/javascript/components/statement_change_summary.js
+++ b/app/javascript/components/statement_change_summary.js
@@ -1,0 +1,6 @@
+import template from './statement_change_summary.html'
+
+export default template({
+  data () { return {} },
+  props: ['statement', 'page']
+})

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -24,7 +24,13 @@ class Statement < ApplicationRecord
   end
 
   def record_actioned!
-    self.actioned_at = Time.now
+    self.actioned_at = Time.zone.now
+    save!
+  end
+
+  def report_error!(error_message)
+    self.error_reported = error_message
+    self.reported_at = Time.zone.now
     save!
   end
 

--- a/db/migrate/20180710103915_add_error_reported_and_reported_at_to_statements.rb
+++ b/db/migrate/20180710103915_add_error_reported_and_reported_at_to_statements.rb
@@ -1,0 +1,6 @@
+class AddErrorReportedAndReportedAtToStatements < ActiveRecord::Migration[5.1]
+  def change
+    add_column :statements, :error_reported, :string
+    add_column :statements, :reported_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180704093403) do
+ActiveRecord::Schema.define(version: 20180710103915) do
 
   create_table "countries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -61,6 +61,8 @@ ActiveRecord::Schema.define(version: 20180704093403) do
     t.boolean "duplicate", default: false
     t.bigint "page_id"
     t.datetime "actioned_at"
+    t.string "error_reported"
+    t.timestamp "reported_at"
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -33,5 +33,17 @@ RSpec.describe StatementsController, type: :controller do
         get :show, params: show_parameters
       end
     end
+
+    context 'when force_type: manually_actionable is provided' do
+      let(:show_parameters) do
+        { id: '123', format: 'json', force_type: 'manually_actionable',
+          error_message: 'Error' }
+      end
+
+      it 'should call report_error!! on statement' do
+        expect(statement).to receive(:report_error!).with('Error')
+        get :show, params: show_parameters
+      end
+    end
   end
 end

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -1,15 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe StatementsController, type: :controller do
-  include ActiveSupport::Testing::TimeHelpers
-
-  let!(:statement) { create(:statement) }
+  let!(:statement) { build(:statement) }
 
   let(:show_parameters) do
     { id: '123', format: 'json' }
   end
 
-  describe "GET #show" do{id: '123', format: 'json'}
+  before do
+    allow(Statement).to receive(:find_by!).with(transaction_id: '123').
+      and_return(statement)
+  end
+
+  describe 'GET #show' do
     it 'returns http success for a transaction that exists' do
       get :show, params: show_parameters
       expect(response).to be_successful
@@ -21,16 +24,13 @@ RSpec.describe StatementsController, type: :controller do
     end
 
     context 'when force_type: done is provided' do
-      let!(:show_parameters) do
+      let(:show_parameters) do
         { id: '123', format: 'json', force_type: 'done' }
       end
 
-      it 'should set actioned_at to a current timestamp' do
-        travel_to Time.zone.local(2017, 11, 24, 01, 04, 44) do
-          get :show, params: show_parameters
-          statement.reload
-          expect(statement.actioned_at).to eq(DateTime.new(2017, 11, 24, 01, 04, 44))
-        end
+      it 'should call record_actioned! on statement' do
+        expect(statement).to receive(:record_actioned!)
+        get :show, params: show_parameters
       end
     end
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Statement, type: :model do
-  let(:statement) { Statement.new }
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:statement) { build(:statement) }
 
   describe 'associations' do
     it 'belongs to a page' do
@@ -20,6 +22,8 @@ RSpec.describe Statement, type: :model do
   end
 
   describe 'validations' do
+    let(:statement) { Statement.new }
+
     it 'requires transaction_id' do
       statement.valid?
       expect(statement.errors).to include(:transaction_id)
@@ -57,6 +61,16 @@ RSpec.describe Statement, type: :model do
       page = create(:page)
       statement = create(:statement, page: page)
       expect(statement.from_suggestions_store?).to eq(false)
+    end
+  end
+
+  describe '#record_actioned!' do
+    before { freeze_time }
+
+    it 'assigns actioned_at' do
+      expect { statement.record_actioned! }.to(
+        change(statement, :actioned_at).from(nil).to(Time.zone.now)
+      )
     end
   end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -73,4 +73,20 @@ RSpec.describe Statement, type: :model do
       )
     end
   end
+
+  describe '#report_error!' do
+    before { freeze_time }
+
+    it 'assigns reported_at' do
+      expect { statement.report_error!('Error') }.to(
+        change(statement, :reported_at).from(nil).to(Time.zone.now)
+      )
+    end
+
+    it 'assigns error_reported' do
+      expect { statement.report_error!('Error') }.to(
+        change(statement, :error_reported).from(nil).to('Error')
+      )
+    end
+  end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -223,6 +223,21 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.reverted).to be_empty }
     end
 
+    context 'when statement has been reported' do
+      before do
+        allow(statement).to receive(:error_reported).and_return('Error!')
+        allow(statement).to receive(:reported_at).and_return(Time.zone.now)
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to eq(statements) }
+      it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
+    end
+
     context 'when the statement has been actioned' do
       before do
         statement.verifications.build(status: true)


### PR DESCRIPTION
Fixes #180 

Work done while pairing with @zarino 

Statements are automatically actioned on Wikidata when entering the `actionable` state after being verified and reconciled.

In effect most people, after clicking the verify or reconcile buttons, will see "short" submitting & updating messages followed by the done message.

![screen shot 2018-07-10 at 12 37 35](https://user-images.githubusercontent.com/5426/42507714-a646dec2-8435-11e8-99f5-011907580144.png)

If errors are raised then we show the error and a summary of the changes we attempted. We originally planned to move statements into the `manually_actionable` state if errors were raised. But on second thoughts felt that they might be transient errors which could be fixed by retrying, or the user might want to leave the statement in the `actionable` state and return at a future point. So the user is then given the option to 'Retry' or 'Report this statement' for someone else to fix. /cc @rich-cassidy / @tmtmtmtm  can you think of better wording for these buttons?

![screen shot 2018-07-10 at 12 11 21](https://user-images.githubusercontent.com/5426/42507312-3a6c7afa-8434-11e8-84c4-60a8c646ee07.png)


Reported statements are moved into the `manually_actionable` state and the error recorded.

![screen shot 2018-07-10 at 12 11 32](https://user-images.githubusercontent.com/5426/42507313-3a8cb43c-8434-11e8-8e4f-6943f9e34f0e.png)

If the page is reloaded when there are statements in the `actionable` state then they will be presented with the existing action.

![screen shot 2018-07-10 at 12 40 49](https://user-images.githubusercontent.com/5426/42507843-1b096b3a-8436-11e8-8737-6221113b7bbd.png)

