### PR TITLE
[#228] Button to retry "fixed" `manually_actionable` statements

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -22,6 +22,8 @@ class StatementsController < FrontendController
       statement.record_actioned!
     when 'manually_actionable'
       statement.report_error!(params[:error_message])
+    when 'actionable'
+      statement.clear_error!
     end
 
     respond_with(statement)

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -53,8 +53,12 @@ class StatementDecorator < SimpleDelegator
   end
 
   def reported_problems
-    return [] unless reported_at
+    return [] unless problem_reported?
     [ error_reported ]
+  end
+
+  def problem_reported?
+    reported_at.present?
   end
 
   def unverifiable?

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -15,7 +15,7 @@ export default template({
   } },
   props: ['statement', 'page', 'country'],
   created: function () {
-    if (['verifiable', 'reconcilable'].indexOf(this.statement.previousType) !== -1) {
+    if (['verifiable', 'reconcilable', 'manually_actionable'].indexOf(this.statement.previousType) !== -1) {
       this.updatePositionHeld()
     }
   },

--- a/app/javascript/components/manually_actionable.html
+++ b/app/javascript/components/manually_actionable.html
@@ -1,9 +1,22 @@
 <span>
-  This statement can't be actioned automatically and will need to be done manually.
-  The problems were:
+  <p>
+    There
+    <span v-if="statement.problems.length == 1">was a problem</span>
+    <span v-else>were problems</span>
+    updating this statement in Wikidata:
+  </p>
   <ul>
     <li v-for="problem in statement.problems">
       {{ problem }}
     </li>
   </ul>
+  <p v-if="statement['problem_reported?']">
+    Once the
+    <span v-if="statement.problems.length == 1">problem is</span>
+    <span v-else>problems are</span>
+    fixed you can <button v-on:click="makeStatementActionable()" class="mw-ui-button mw-ui-progressive">Retry updating the statement</button>
+  </p>
+  <p v-else>
+    You'll need to update this manually on Wikidata.
+  </p>
 </span>

--- a/app/javascript/components/manually_actionable.js
+++ b/app/javascript/components/manually_actionable.js
@@ -1,6 +1,18 @@
+import ENV from '../env'
+import Axios from 'axios'
 import template from './manually_actionable.html'
 
 export default template({
   data () { return {} },
-  props: ['statement', 'page', 'country']
+  props: ['statement', 'page', 'country'],
+  methods: {
+    makeStatementActionable: function () {
+      this.$parent.$emit('statement-update', () => {
+        return Axios.get(
+          ENV.url + '/statements/' + this.statement.transaction_id + '.json',
+          { params: { force_type: 'actionable' } }
+        )
+      })
+    }
+  }
 })

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -34,6 +34,12 @@ class Statement < ApplicationRecord
     save!
   end
 
+  def clear_error!
+    self.error_reported = nil
+    self.reported_at = nil
+    save!
+  end
+
   def recently_actioned?
     # Was this statement actioned in the last 5 minutes?
     return false unless actioned_at

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -15,6 +15,7 @@ json.statements @classifier.to_a do |statement|
     :parliamentary_group_name,
     :electoral_district_name,
     :problems,
+    :problem_reported?,
     :reconciliations
   )
 

--- a/spec/controllers/statements_controller_spec.rb
+++ b/spec/controllers/statements_controller_spec.rb
@@ -45,5 +45,16 @@ RSpec.describe StatementsController, type: :controller do
         get :show, params: show_parameters
       end
     end
+
+    context 'when force_type: actionable is provided' do
+      let(:show_parameters) do
+        { id: '123', format: 'json', force_type: 'actionable' }
+      end
+
+      it 'should call clear_error! on statement' do
+        expect(statement).to receive(:clear_error!)
+        get :show, params: show_parameters
+      end
+    end
   end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -89,4 +89,22 @@ RSpec.describe Statement, type: :model do
       )
     end
   end
+
+  describe '#clear_error!' do
+    let(:statement) do
+      build(:statement, reported_at: Time.zone.now, error_reported: 'Error')
+    end
+
+    it 'unassigns reported_at' do
+      expect { statement.clear_error! }.to(
+        change(statement, :reported_at).to(nil)
+      )
+    end
+
+    it 'unassigns error_reported' do
+      expect { statement.clear_error! }.to(
+        change(statement, :error_reported).to(nil)
+      )
+    end
+  end
 end


### PR DESCRIPTION
Fixes #228.

Tweaks the `manually_actionable` template to include a button that lets you retry the statement update in Wikidata, once you think the previously reported error has been fixed.

![screen shot 2018-07-10 at 17 27 22](https://user-images.githubusercontent.com/5426/42523738-24f43562-845e-11e8-97b5-7a096627f5d1.png)
