### PR TITLE
[#224] Bulk party reconcilation

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -5,9 +5,14 @@
 class FrontendController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  def respond_with(statement)
+  def respond_with(statement, statements = nil)
     page = statement.page
-    @classifier = StatementClassifier.new(page.title, statement.transaction_id)
+    statements ||= [statement]
+
+    @classifier = StatementClassifier.new(
+      page.title,
+      statements.map(&:transaction_id)
+    )
 
     respond_to do |format|
       format.json { render file: 'statements/index' }

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -6,6 +6,7 @@ class FrontendController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def respond_with(statement, statements = nil)
+    @bulk_update = statements && (statements.length > 1)
     page = statement.page
     statements ||= [statement]
 

--- a/app/controllers/reconciliations_controller.rb
+++ b/app/controllers/reconciliations_controller.rb
@@ -4,15 +4,15 @@
 # Wikidata
 class ReconciliationsController < FrontendController
   def create
+    params[:update_type] ||= 'single'
     statement = Statement.find_by!(transaction_id: params.fetch(:id))
-    statement.reconciliations.create!(reconciliation_params)
-
-    respond_with(statement)
+    reconciliation = statement.reconciliations.create!(reconciliation_params)
+    respond_with(statement, reconciliation.possibly_updated_statements)
   end
 
   private
 
   def reconciliation_params
-    params.permit(%i[user item resource_type])
+    params.permit(%i[user item resource_type update_type])
   end
 end

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -31,16 +31,14 @@ export default template({
     this.loadStatements()
     this.$on('statement-update', (requestFunction, cb) => {
       requestFunction().then(response => {
-        if (response.data.statements.length > 1) {
-          throw 'Response has too many statements. We don\'t know which one to update'
-        }
-        var newStatement = response.data.statements[0]
-        const index = this.statements.findIndex(s => {
-          return s.transaction_id === newStatement.transaction_id
-        })
-        const previousType = this.statements[index].type
-        newStatement.previousType = previousType
-        this.statements.splice(index, 1, newStatement)
+        response.data.statements.forEach(function (newStatement) {
+          var index = this.statements.findIndex(s => {
+            return s.transaction_id === newStatement.transaction_id
+          })
+          var previousType = this.statements[index].type
+          newStatement.previousType = previousType
+          this.statements.splice(index, 1, newStatement)
+        }, this)
       }).then(cb)
     })
     this.$on('statements-loaded', () => {

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -48,7 +48,25 @@ export default template({
           this.$emit('scroll-to-fragment', hash)
         }
       })
-    }),
+    })
+    this.$on('find-matching-statements', (data, cb) => {
+      const {resourceType, statement, nameAttr, itemAttr, newItem} = data
+      if (resourceType === 'person')  {
+        cb(0, 0);
+        return;
+      }
+      let otherMatching = this.statements.filter(s => {
+        return nameAttr && itemAttr && statement[nameAttr] &&
+          (s[nameAttr] === statement[nameAttr]) &&
+          (s[itemAttr] !== newItem) &&
+          (s.transaction_id != statement.transaction_id)
+      })
+      let otherMatchingUnreconciled = otherMatching.filter(s => !s[itemAttr])
+      cb({
+        otherMatching: otherMatching.length,
+        otherMatchingUnreconciled: otherMatchingUnreconciled.length
+      })
+    })
     this.$on('scroll-to-fragment', (fragment) => {
       let selector = fragment.replace(/:/g, '\\:')
       let statementRow = document.querySelector(selector)

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -14,6 +14,14 @@ export default template({
   } },
   props: ['statement', 'page', 'country'],
   created: function () {
+    if (this.statement.bulk_update) {
+      // To avoid lots of statements being actioned in parallel, which
+      // is bad API usage etiquette, we don't automatically action
+      // this statement if it appears to come from a bulk update:
+      this.statement.bulk_update = false
+      return;
+    }
+    this.statement.bulk_update = false
     if (['verifiable', 'reconcilable', 'manually_actionable'].indexOf(this.statement.previousType) !== -1) {
       this.updatePositionHeld()
     }

--- a/app/javascript/components/done.js
+++ b/app/javascript/components/done.js
@@ -2,5 +2,8 @@ import template from './done.html'
 
 export default template({
   data () { return {} },
-  props: ['statement', 'page', 'country']
+  props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  }
 })

--- a/app/javascript/components/manually_actionable.js
+++ b/app/javascript/components/manually_actionable.js
@@ -5,6 +5,9 @@ import template from './manually_actionable.html'
 export default template({
   data () { return {} },
   props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  },
   methods: {
     makeStatementActionable: function () {
       this.$parent.$emit('statement-update', () => {

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -1,5 +1,22 @@
 <span>
-  <span v-if="!searchResults">
+  <span v-if="askAboutBulkUpdate">
+    <div>
+      <input type="radio" id="bulk-update-single" value="single" v-model="bulkUpdateType">
+      <label for="bulk-update-single">Just update this statement</label>
+    </div>
+    <div v-if="bulkUpdateCounts.otherMatchingUnreconciled > 0">
+      <input type="radio" id="bulk-update-also_matching_unreconciled" value="also_matching_unreconciled" v-model="bulkUpdateType">
+      <label for="bulk-update-also_matching_unreconciled">Also update {{ bulkUpdateCounts.otherMatchingUnreconciled }} other unreconciled occurences of {{ bulkName }}?</label>
+    </div>
+    <div v-if="bulkUpdateCounts.otherMatching != bulkUpdateCounts.otherMatchingUnreconciled">
+      <input type="radio" id="bulk-update-also_matching" value="also_matching" v-model="bulkUpdateType">
+      <label for="bulk-update-also_matching">Also update {{ bulkUpdateCounts.otherMatching }} other occurences of {{ bulkName }} (including {{ bulkUpdateCounts.otherMatching - bulkUpdateCounts.otherMatchingUnreconciled }} already reconciled with a different item)?</label>
+    </div>
+    <div>
+      <button v-on:click="bulkReconcileWithItem(bulkUpdateItem)">Continue</button>
+    </div>
+  </span>
+  <span v-else-if="!searchResults">
     <p>Click above to reconcile Subject, District, or Parliamentary group.</p>
   </span>
   <span v-else>

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -15,6 +15,9 @@ export default template({
     languageCode: 'en'
   } },
   props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  },
   computed: {
     bulkFieldPrefix: function() {
       return {

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -8,9 +8,24 @@ export default template({
     searchTerm: null,
     searchResults: null,
     searchResourceType: null,
+    askAboutBulkUpdate: false,
+    bulkUpdateItem: null,
+    bulkUpdateType: null,
+    bulkUpdateCounts: null,
     languageCode: 'en'
   } },
   props: ['statement', 'page', 'country'],
+  computed: {
+    bulkFieldPrefix: function() {
+      return {
+        'district': 'electoral_district_',
+        'party': 'parliamentary_group_'
+      }[this.searchResourceType]
+    },
+    bulkItemAttr: function () { return this.bulkFieldPrefix && (this.bulkFieldPrefix + 'item')},
+    bulkNameAttr: function () { return this.bulkFieldPrefix && (this.bulkFieldPrefix + 'name')},
+    bulkName: function() { return this.statement[this.bulkNameAttr] }
+  },
   created: function () {
     this.languageCode = this.getLanguageCode();
 
@@ -58,17 +73,54 @@ export default template({
         this.$parent.$emit('loaded')
       })
     },
-    reconcileWithItem: function(itemID) {
+    createReconciliation: function(itemID, updateType) {
       this.$parent.$emit('statement-update', () => {
         return Axios.post(ENV.url + '/reconciliations.json', {
           id: this.statement.transaction_id,
           user: wikidataClient.user,
           item: itemID,
-          resource_type: this.searchResourceType
+          resource_type: this.searchResourceType,
+          update_type: updateType
         })
       })
+    },
+    bulkReconcileWithItem: function(itemID) {
+      this.askAboutBulkUpdate = false
+      this.bulkUpdateItem = null
+      if (this.bulkUpdateType) {
+        this.createReconciliation(itemID, this.bulkUpdateType)
+      }
       this.searchResults = null
       this.searchResourceType = null
+    },
+    reconcileWithItem: function (itemID) {
+      let self = this
+      // See if there are any other statements with the same name for
+      // this resource type:
+      this.$parent.$parent.$emit(
+        'find-matching-statements',
+        {
+          resourceType: this.searchResourceType,
+          statement: this.statement,
+          nameAttr: this.bulkNameAttr,
+          itemAttr: this.bulkItemAttr,
+          newItem: itemID,
+        },
+        function (counts) {
+          self.bulkUpdateCounts = counts
+          if (self.bulkUpdateCounts.otherMatching > 0) {
+            // Ask whether to do a bulk reconciliation:
+            self.askAboutBulkUpdate = true
+            self.bulkUpdateItem = itemID
+            self.searchResults = null
+          } else {
+            // Or go ahead and reconcile just this item:
+            self.createReconciliation(itemID, 'single')
+            self.searchResults = null
+            self.searchResourceType = null
+          }
+        }
+      )
     },
     createPerson: function() {
       wikidataClient.createPerson(

--- a/app/javascript/components/reverted.js
+++ b/app/javascript/components/reverted.js
@@ -2,5 +2,8 @@ import template from './reverted.html'
 
 export default template({
   data () { return {} },
-  props: ['statement', 'page', 'country']
+  props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  }
 })

--- a/app/javascript/components/unverifiable.js
+++ b/app/javascript/components/unverifiable.js
@@ -2,5 +2,8 @@ import template from './unverifiable.html'
 
 export default template({
   data () { return {} },
-  props: ['statement', 'page', 'country']
+  props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  }
 })

--- a/app/javascript/components/verifiable.js
+++ b/app/javascript/components/verifiable.js
@@ -6,6 +6,9 @@ import template from './verifiable.html'
 export default template({
   data () { return {} },
   props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  },
   methods: {
     submitStatement: function (status) {
       this.$parent.$emit('statement-update', () => {

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -4,23 +4,62 @@
 class Reconciliation < ApplicationRecord
   belongs_to :statement
 
+  enum update_type: %i[single also_matching_unreconciled also_matching]
+
   validates :item, :resource_type, presence: true
 
   default_scope -> { order(updated_at: :asc) }
 
   after_commit :update_statement, :create_equivalence_claim
 
+  def possibly_updated_statements
+    return Statement.where(id: statement.id) if single
+    Statement.where(id: statement.id).or(Statement.where(where_condition_matching_name))
+  end
+
   private
 
   def update_statement
-    case resource_type
-    when 'person'
-      statement.update(person_item: item)
-    when 'party'
-      statement.update(parliamentary_group_item: item)
-    when 'district'
-      statement.update(electoral_district_item: item)
-    end
+    statement.update(item_attr => item)
+    return if single
+    other_statements_for_update.update(item_attr => item)
+  end
+
+  def single
+    resource_type == 'person' || update_type == 'single'
+  end
+
+  def other_statements_for_update
+    Statement.where(where_condition_for_update).where.not(id: statement.id)
+  end
+
+  def name_attr
+    resource_attrs[:name]
+  end
+
+  def item_attr
+    resource_attrs[:item]
+  end
+
+  def resource_attrs
+    {
+      'person'   => { item: :person_item,              name: :person_name },
+      'party'    => { item: :parliamentary_group_item, name: :parliamentary_group_name },
+      'district' => { item: :electoral_district_item,  name: :electoral_district_name },
+    }[resource_type]
+  end
+
+  def where_condition_matching_name
+    {
+      :page     => statement.page,
+      name_attr => statement.public_send(name_attr),
+    }
+  end
+
+  def where_condition_for_update
+    where_condition = where_condition_matching_name.clone
+    where_condition[item_attr] = nil if update_type == 'also_matching_unreconciled'
+    where_condition
   end
 
   def create_equivalence_claim

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -4,16 +4,16 @@
 class StatementClassifier
   attr_reader :page, :statements, :transaction_id
 
-  def initialize(page_title, transaction_id = nil)
+  def initialize(page_title, transaction_ids = nil)
     @page = Page.find_by!(title: page_title)
     @statements = page.statements.original
                       .includes(:verifications)
                       .references(:verifications)
                       .order(:id)
-    @transaction_id = transaction_id
 
-    return unless transaction_id
-    @statements = @statements.where(transaction_id: transaction_id)
+    return unless transaction_ids
+    @transaction_id = transaction_ids.first if transaction_ids.count == 1
+    @statements = @statements.where(transaction_id: transaction_ids)
   end
 
   # verifiable

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -28,6 +28,8 @@ json.statements @classifier.to_a do |statement|
     json.verified_on nil
     json.verification_status nil
   end
+
+  json.bulk_update @bulk_update
 end
 
 json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language

--- a/db/migrate/20180728130458_add_update_type_to_reconciliations.rb
+++ b/db/migrate/20180728130458_add_update_type_to_reconciliations.rb
@@ -1,0 +1,5 @@
+class AddUpdateTypeToReconciliations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reconciliations, :update_type, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_23_140444) do
+ActiveRecord::Schema.define(version: 2018_07_28_130458) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2018_07_23_140444) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "resource_type"
+    t.integer "update_type", default: 0
     t.index ["statement_id"], name: "index_reconciliations_on_statement_id"
   end
 

--- a/spec/controllers/reconciliations_controller_spec.rb
+++ b/spec/controllers/reconciliations_controller_spec.rb
@@ -7,34 +7,73 @@ RSpec.describe ReconciliationsController, type: :controller do
   let(:relation) { double(:reconciliation_relation).as_null_object }
   let(:classifier) { double(:classifier) }
 
-  let(:valid_attributes) do
-    { id: '123', user: 'ExampleUser', item: 'Q1', resource_type: 'person',
-      format: 'json', }
+  context 'reconciling a person_name' do
+    let(:valid_attributes) do
+      { id: '123', user: 'ExampleUser', item: 'Q1', resource_type: 'person',
+        format: 'json', }
+    end
+
+    describe 'POST #create' do
+      context 'no update_type is supplied (the old protocol)' do
+        before do
+          allow(Statement).to receive(:find_by!).and_return(statement)
+          allow(statement).to receive(:reconciliations).and_return(relation)
+          allow(StatementClassifier).to receive(:new).and_return(classifier)
+        end
+
+        it 'finds statement and creates reconciliation' do
+          expect(Statement).to receive(:find_by!).with(transaction_id: '123')
+          post :create, params: valid_attributes
+          expect(relation).to have_received(:create!)
+            .with('user' => 'ExampleUser', 'item' => 'Q1',
+                  'resource_type' => 'person', 'update_type' => 'single')
+        end
+
+        it 'assigns classifier' do
+          post :create, params: valid_attributes
+          expect(assigns(:classifier)).to eq classifier
+        end
+
+        it 'renders statements show JSON' do
+          post :create, params: valid_attributes
+          expect(response).to render_template('statements/index')
+        end
+      end
+    end
   end
 
-  describe 'POST #create' do
-    before do
-      allow(Statement).to receive(:find_by!).and_return(statement)
-      allow(statement).to receive(:reconciliations).and_return(relation)
-      allow(StatementClassifier).to receive(:new).and_return(classifier)
+  context 'reconciling an electoral_district_name' do
+    let(:valid_attributes) do
+      { id: '123', user: 'ExampleUser', item: 'Q13', resource_type: 'district',
+        update_type: 'also_matching', format: 'json', }
     end
 
-    it 'finds statement and creates reconciliation' do
-      expect(Statement).to receive(:find_by!).with(transaction_id: '123')
-      post :create, params: valid_attributes
-      expect(relation).to have_received(:create!)
-        .with('user' => 'ExampleUser', 'item' => 'Q1',
-              'resource_type' => 'person')
-    end
+    describe 'POST #create' do
+      context 'an update type of also_matching is supplied' do
+        before do
+          allow(Statement).to receive(:find_by!).and_return(statement)
+          allow(statement).to receive(:reconciliations).and_return(relation)
+          allow(StatementClassifier).to receive(:new).and_return(classifier)
+        end
 
-    it 'assigns classifier' do
-      post :create, params: valid_attributes
-      expect(assigns(:classifier)).to eq classifier
-    end
+        it 'finds statement and creates reconciliation' do
+          expect(Statement).to receive(:find_by!).with(transaction_id: '123')
+          post :create, params: valid_attributes
+          expect(relation).to have_received(:create!)
+            .with('user' => 'ExampleUser', 'item' => 'Q13',
+                  'resource_type' => 'district', 'update_type' => 'also_matching')
+        end
 
-    it 'renders statements show JSON' do
-      post :create, params: valid_attributes
-      expect(response).to render_template('statements/index')
+        it 'assigns classifier' do
+          post :create, params: valid_attributes
+          expect(assigns(:classifier)).to eq classifier
+        end
+
+        it 'renders statements show JSON' do
+          post :create, params: valid_attributes
+          expect(response).to render_template('statements/index')
+        end
+      end
     end
   end
 end

--- a/spec/models/reconciliation_spec.rb
+++ b/spec/models/reconciliation_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Reconciliation, type: :model do
-  let(:reconciliation) { Reconciliation.new }
+  let(:reconciliation) { Reconciliation.new(update_type: 'single') }
 
   describe 'associations' do
     it 'belong to statement' do
@@ -75,6 +75,163 @@ RSpec.describe Reconciliation, type: :model do
           .with(electoral_district_item: 'Q6').once
         reconciliation.item = 'Q6'
         reconciliation.save! # update
+      end
+    end
+
+    context 'the update_type is also_matching_unreconciled' do
+      before { reconciliation.update_type = 'also_matching_unreconciled' }
+
+      context 'person resource_type' do
+        before { reconciliation.resource_type = 'person' }
+
+        let(:statement) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '126', page: statement.page, person_item: 'Q7323')
+        end
+
+        it 'should only update the particular statement' do
+          expect(statement).to receive(:update)
+            .with(person_item: 'Q123').once
+          reconciliation.item = 'Q123'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.person_item).to be_nil
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.person_item).to eq('Q7323')
+        end
+      end
+
+      context 'party resource_type' do
+        before { reconciliation.resource_type = 'party' }
+
+        let(:statement) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '126', page: statement.page, parliamentary_group_item: 'Q137')
+        end
+
+        it 'should update the original statement and the unreconciled one, but not one matched to a different item' do
+          expect(statement).to receive(:update)
+            .with(parliamentary_group_item: 'Q135').once
+          reconciliation.item = 'Q135'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.parliamentary_group_item).to eq('Q135')
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.parliamentary_group_item).to eq('Q137')
+        end
+      end
+
+      context 'district resource_type' do
+        before { reconciliation.resource_type = 'district' }
+
+        let(:statement) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '126', page: statement.page, electoral_district_item: 'Q137')
+        end
+
+        it 'should update the original statement and the unreconciled one, but not one matched to a different item' do
+          expect(statement).to receive(:update)
+            .with(electoral_district_item: 'Q135').once
+          reconciliation.item = 'Q135'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.electoral_district_item).to eq('Q135')
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.electoral_district_item).to eq('Q137')
+        end
+      end
+    end
+
+    context 'the update_type is also_matching' do
+      before { reconciliation.update_type = 'also_matching' }
+      context 'person resource_type' do
+        before { reconciliation.resource_type = 'person' }
+
+        let(:statement) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, person_name: 'Joe Bloggs', transaction_id: '126', page: statement.page, person_item: 'Q7323')
+        end
+
+        it 'should only update the particular statement' do
+          expect(statement).to receive(:update)
+            .with(person_item: 'Q123').once
+          reconciliation.item = 'Q123'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.person_item).to be_nil
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.person_item).to eq('Q7323')
+        end
+      end
+
+      context 'party resource_type' do
+        before { reconciliation.resource_type = 'party' }
+
+        let(:statement) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, parliamentary_group_name: 'OMRLP', transaction_id: '126', page: statement.page, parliamentary_group_item: 'Q137')
+        end
+
+        it 'should update the original statement and the unreconciled one, but not one matched to a different item' do
+          expect(statement).to receive(:update)
+            .with(parliamentary_group_item: 'Q135').once
+          reconciliation.item = 'Q135'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.parliamentary_group_item).to eq('Q135')
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.parliamentary_group_item).to eq('Q135')
+        end
+      end
+
+      context 'district resource_type' do
+        before { reconciliation.resource_type = 'district' }
+
+        let(:statement) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '124')
+        end
+        let!(:statement_unreconciled) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '125', page: statement.page)
+        end
+        let!(:statement_reconciled_to_different_item) do
+          create(:statement, electoral_district_name: 'OMRLP', transaction_id: '126', page: statement.page, electoral_district_item: 'Q137')
+        end
+
+        it 'should update the original statement and the unreconciled one, but not one matched to a different item' do
+          expect(statement).to receive(:update)
+            .with(electoral_district_item: 'Q135').once
+          reconciliation.item = 'Q135'
+          reconciliation.save!
+          statement_unreconciled.reload
+          expect(statement_unreconciled.electoral_district_item).to eq('Q135')
+          statement_reconciled_to_different_item.reload
+          expect(statement_reconciled_to_different_item.electoral_district_item).to eq('Q135')
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #224 

Work done while pairing with @zarino.

Reconciling the a party will now also update other statements for the same party that are on the same page.

This all seems to be working but labelled as work in progress as the Ruby code needs tests updated/written. And the commit messages needs updating too. The frontend changes look good.

Switching to other features for now to make most use of pairing time.