### PR TITLE
(Re-)generate verification pages daily

### DIFF
--- a/lib/tasks/verification_page.rake
+++ b/lib/tasks/verification_page.rake
@@ -5,6 +5,15 @@ namespace :verification_page do
     puts GenerateVerificationPage.run(args.page_title)
   end
 
+  namespace :generate do
+    desc 'Create or update all verification pages'
+    task all: :environment do
+      Page.find_each do |page|
+        puts GenerateVerificationPage.run(page.title)
+      end
+    end
+  end
+
   desc 'Update verification page for the page_title given'
   task :update, %i[page_title] => %i[environment] do |_, args|
     begin

--- a/script/toolforge-cron.daily
+++ b/script/toolforge-cron.daily
@@ -10,3 +10,4 @@ source ./script/toolforge-setup
 
 # Add all the scripts that you want to be run daily here
 bin/rails verification_page:load:all
+bin/rails verification_page:generate:all


### PR DESCRIPTION
Adds a rake task that iterates through the existing pages and re-generates the associated verification page on Wikidata. Also updates the crontab to include running that rake task.

Fixes #31 