### PR TITLE
Link to Wikidata page from list of pages

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -20,7 +20,7 @@
     <% @pages.each do |page| %>
       <tr>
         <td><%= link_to page.id, page_path(page) %></td>
-        <td><%= page.title %></td>
+        <td><%= link_to page.title, "https://#{ENV['WIKIDATA_SITE']}/wiki/#{page.title}" %></td>
         <td><%= link_to page.country.name, page.country %></td>
         <td><%= page.position_held_item %></td>
         <td><%= page.parliamentary_term_item %></td>


### PR DESCRIPTION
This makes it easier to actually view the page on Wikidata.

Fixes #261 