### PR TITLE
[#169] Fix creating people when reconciling

### DIFF
--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -447,7 +447,7 @@ var wikidata = function(spec) {
       language: label.lang,
       value: label.value,
     };
-    data.descriptions[label.lang] = {
+    data.descriptions[description.lang] = {
       language: description.lang,
       value: description.value,
     };


### PR DESCRIPTION
Fixes #169

Description languages need to match otherwise an "inconsitent-language" errors are raised.

