### PR TITLE
[#219] Show progress bar above verification tool controls

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -104,16 +104,97 @@ $color_pale_grey: #eee;
 }
 
 .verification-tool__statement-controls--unverifiable {
-    border-color: $color_mid_red;
-    background-color: $color_pale_red;
+    border-color: $color_mid_grey;
+    background-color: $color_pale_grey;
 }
 
-.verification-tool__statement-controls--done {
+.verification-tool__statement-controls--done,
+.verification-tool__statement-controls--reverted {
     border-color: $color_mid_green;
     background-color: $color_pale_green;
 }
 
 .verification-tool__statement-controls--manually_actionable {
-    border-color: $color_mid_grey;
-    background-color: $color_pale_grey;
+    border-color: $color_mid_red;
+    background-color: $color_pale_red;
+}
+
+.verification-tool__progress {
+    margin: 1.5em 0 1em;
+}
+
+.verification-tool__progress__bar {
+    margin-top: 0.5em;
+    background: $color_pale_grey;
+    height: 1em;
+    overflow: auto;
+
+    & > * {
+        float: left;
+        height: 1em;
+    }
+
+    .actionable,
+    .verifiable,
+    .reconcilable {
+        background: $color_mid_blue;
+    }
+
+    .done,
+    .reverted {
+        background: $color_mid_green;
+    }
+
+    .unverifiable {
+        background: $color_pale_grey;
+    }
+
+    .manually_actionable {
+        background: $color_mid_red;
+    }
+}
+
+.verification-tool__progress__summary {
+    display: flex;
+    justify-content: space-between;
+
+    div {
+        color: $color_mid_grey;
+
+        &:before {
+            content: "";
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            border-radius: 10px;
+            margin-right: 0.4em;
+        }
+    }
+
+    .actionable,
+    .verifiable,
+    .reconcilable {
+        &:before {
+            background: $color_mid_blue;
+        }
+    }
+
+    .done,
+    .reverted {
+        &:before {
+            background: $color_mid_green;
+        }
+    }
+
+    .unverifiable {
+        &:before {
+            background: $color_pale_grey;
+        }
+    }
+
+    .manually_actionable {
+        &:before {
+            background: $color_mid_red;
+        }
+    }
 }

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -1,14 +1,14 @@
 <div id="verification-tool">
   <div v-if="loaded">
       <Progress :counts="{
-        all: 333,
-        verifiable: 150,
-        unverifiable: 40,
-        reconcilable: 10,
-        actionable: 0,
-        manually_actionable: 30,
-        done: 90,
-        reverted: 13
+        all: countStatementsOfType('all'),
+        verifiable: countStatementsOfType('verifiable'),
+        unverifiable: countStatementsOfType('unverifiable'),
+        reconcilable: countStatementsOfType('reconcilable'),
+        actionable: countStatementsOfType('actionable'),
+        manually_actionable: countStatementsOfType('manually_actionable'),
+        done: countStatementsOfType('done'),
+        reverted: countStatementsOfType('reverted')
       }" />
   </div>
   <div v-if="loaded" class="verification-tool__controls">

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -1,4 +1,16 @@
 <div id="verification-tool">
+  <div v-if="loaded">
+      <Progress :counts="{
+        all: 333,
+        verifiable: 150,
+        unverifiable: 40,
+        reconcilable: 10,
+        actionable: 0,
+        manually_actionable: 30,
+        done: 90,
+        reverted: 13
+      }" />
+  </div>
   <div v-if="loaded" class="verification-tool__controls">
     <div class="verification-tool__controls__group">
       <label for="displayType">Type</label>

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import ENV from './env'
 import Axios from 'axios'
 import wikidataClient from './wikiapi'
@@ -10,6 +11,9 @@ import actionableComponent from './components/actionable'
 import manuallyActionableComponent from './components/manually_actionable'
 import doneComponent from './components/done'
 import revertedComponent from './components/reverted'
+import progressComponent from './components/progress'
+
+Vue.component('Progress', progressComponent)
 
 export default template({
   data () {

--- a/app/javascript/components/progress.html
+++ b/app/javascript/components/progress.html
@@ -1,0 +1,20 @@
+<div class="verification-tool__progress">
+  <div class="verification-tool__progress__summary">
+    <div class="done">{{ counts['done'] }} Done</div>
+    <div class="reverted">{{ counts['reverted'] }} Reverted</div>
+    <div class="manually_actionable">{{ counts['manually_actionable'] }} Manually actionable</div>
+    <div class="actionable">{{ counts['actionable'] }} Actionable</div>
+    <div class="reconcilable">{{ counts['reconcilable'] }} Reconcilable</div>
+    <div class="verifiable">{{ counts['verifiable'] }} Verifiable</div>
+    <div class="unverifiable">{{ counts['unverifiable'] }} Unverifiable</div>
+  </div>
+  <div class="verification-tool__progress__bar">
+    <div :style="styleForType('done')" class="done"></div>
+    <div :style="styleForType('reverted')" class="reverted"></div>
+    <div :style="styleForType('manually_actionable')" class="manually_actionable"></div>
+    <div :style="styleForType('actionable')" class="actionable"></div>
+    <div :style="styleForType('reconcilable')" class="reconcilable"></div>
+    <div :style="styleForType('verifiable')" class="verifiable"></div>
+    <div :style="styleForType('unverifiable')" class="unverifiable"></div>
+  </div>
+</div>

--- a/app/javascript/components/progress.js
+++ b/app/javascript/components/progress.js
@@ -1,0 +1,16 @@
+import template from './progress.html'
+
+export default template({
+  data () { return {} },
+  props: [
+    'counts'
+  ],
+  methods: {
+    percentageForType: function (type) {
+      return (this.counts[type] / this.counts['all']) * 100;
+    },
+    styleForType: function (type) {
+      return 'width: ' + this.percentageForType(type) + '%';
+    }
+  }
+})


### PR DESCRIPTION
Fixes #219.

@mhl @tmtmtmtm @rich-cassidy do you feel this gives a clear enough picture of your "progress"? Or should we highlight _only_ done/reverted statements?

![screen shot 2018-07-13 at 10 22 46](https://user-images.githubusercontent.com/739624/42683988-cb0fff2e-8686-11e8-8832-0e5083f1423b.png)
