### PR TITLE
[#62] Configurable Wikipedia (language) search

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -38,6 +38,20 @@ $color_pale_grey: #eee;
         padding: 1em;
         vertical-align: top;
     }
+
+    h3 {
+        .mw-ui-button {
+            font-size: 0.8em;
+            margin: 0 0.5em;
+        }
+
+        .language-chooser {
+            width: 3em;
+            font-weight: inherit;
+            font-size: inherit;
+            text-align: right;
+        }
+    }
 }
 
 .verification-tool__blank-slate {

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -9,20 +9,20 @@
   <span v-if="searchResultsLoaded">
     <span v-if="this.searchResourceType === 'person'">
       <h3>Create a new item</h3>
-      <button v-on:click="createPerson()">Create {{ statement.person_name }}</button>
+      <button v-on:click="createPerson()" class="mw-ui-button">Create {{ statement.person_name }}</button>
     </span>
     <h3>Wikidata search results</h3>
     <ul class="wd-search-results">
       <li v-for="wdResult in searchResults.fromWikidata">
-        <button v-on:click="reconcileWithItem(wdResult.item)">Use this</button>
+        <button v-on:click="reconcileWithItem(wdResult.item)" class="mw-ui-button">Use this</button>
         <span class="item-from-search">{{ wdResult.item }}</span>
         <a target="_blank" rel="noopener nofollow" class="external free" :href="wdResult.url">{{ wdResult.label }} ({{ wdResult.description }})</a>
       </li>
     </ul>
-    <h3>Wikipedia search results</h3>
+    <h3><input v-if="languageChooserActive" v-model="languageCode" class="language-chooser"><span v-else>{{ languageCode }}</span>.wikipedia.org search results <button v-on:click="toggleLanguageChooser()" v-if="!languageChooserActive" class="mw-ui-button">Choose a different Wikipedia</button><button v-else v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Save &amp; Search</button></h3>
     <ul class="wp-search-results">
       <li v-for="wpResult in searchResults.fromWikipedia">
-        <button v-on:click="reconcileWithItem(wpResult.item)">Use this</button>
+        <button v-on:click="reconcileWithItem(wpResult.item)" class="mw-ui-button">Use this</button>
         <span class="item-from-search">{{ wpResult.item }}</span>
         <a target="_blank" rel="noopener nofollow" class="external free" :href="wpResult.wpURL">{{ wpResult.title }} </a>
         <div v-html="wpResult.snippetHTML"></div>

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -19,7 +19,7 @@
         <a target="_blank" rel="noopener nofollow" class="external free" :href="wdResult.url">{{ wdResult.label }} ({{ wdResult.description }})</a>
       </li>
     </ul>
-    <h3><input v-if="languageChooserActive" v-model="languageCode" class="language-chooser"><span v-else>{{ languageCode }}</span>.wikipedia.org search results <button v-on:click="toggleLanguageChooser()" v-if="!languageChooserActive" class="mw-ui-button">Choose a different Wikipedia</button><button v-else v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Save &amp; Search</button></h3>
+    <h3><input v-if="languageChooserActive" v-model="languageCode" class="language-chooser"><span v-else>{{ languageCode }}</span>.wikipedia.org search results <button v-on:click="toggleLanguageChooser()" v-if="!languageChooserActive" class="mw-ui-button">Choose a different Wikipedia</button><button v-else v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Update results</button></h3>
     <ul class="wp-search-results">
       <li v-for="wpResult in searchResults.fromWikipedia">
         <button v-on:click="reconcileWithItem(wpResult.item)" class="mw-ui-button">Use this</button>

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -8,7 +8,9 @@ export default template({
     searchResultsLoading: false,
     searchResultsLoaded: false,
     searchResults: null,
-    searchResourceType: null
+    searchResourceType: null,
+    languageCode: 'en',
+    languageChooserActive: false
   } },
   props: ['statement', 'page', 'country'],
   created: function () {
@@ -27,8 +29,9 @@ export default template({
       this.search(this.statement.parliamentary_group_name)
     },
     search: function (searchTerm) {
+      this.searchResultsLoaded = false;
       this.searchResultsLoading = true;
-      wikidataClient.search(searchTerm, 'en', 'en').then(data => {
+      wikidataClient.search(searchTerm, this.languageCode, 'en').then(data => {
         console.log(data);
         this.searchResults = data;
         this.searchResultsLoaded = true;
@@ -59,5 +62,16 @@ export default template({
         this.reconcileWithItem(createdItemData.item);
       })
     },
+    toggleLanguageChooser: function () {
+      this.languageChooserActive = !this.languageChooserActive;
+    },
+    changeLanguage: function () {
+      this.languageChooserActive = false;
+      if (this.searchResourceType == 'person') {
+        this.search(this.statement.person_name);
+      } else if (this.searchResourceType == 'party') {
+        this.search(this.statement.parliamentary_group_name)
+      }
+    }
   }
 })

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -18,6 +18,7 @@ export default template({
       this.searchResultsLoading = false
       this.searchResultsLoaded = false
     })
+    this.languageCode = this.getLanguageCode();
   },
   methods: {
     searchForName: function () {
@@ -31,7 +32,7 @@ export default template({
     search: function (searchTerm) {
       this.searchResultsLoaded = false;
       this.searchResultsLoading = true;
-      wikidataClient.search(searchTerm, this.languageCode, 'en').then(data => {
+      wikidataClient.search(searchTerm, this.getLanguageCode(), 'en').then(data => {
         console.log(data);
         this.searchResults = data;
         this.searchResultsLoaded = true;
@@ -67,11 +68,16 @@ export default template({
     },
     changeLanguage: function () {
       this.languageChooserActive = false;
+      localStorage.setItem(wikidataClient.page + '.language', this.languageCode);
+
       if (this.searchResourceType == 'person') {
         this.search(this.statement.person_name);
       } else if (this.searchResourceType == 'party') {
         this.search(this.statement.parliamentary_group_name)
       }
+    },
+    getLanguageCode: function () {
+      return localStorage.getItem(wikidataClient.page + '.language') || this.languageCode;
     }
   }
 })


### PR DESCRIPTION
Fixes #62.

User can override the Wikipedia against which reconciliations searches are performed. The setting defaults to `en.wikipedia.org`, but any country code can be entered – even if it’s not a real wikipedia. (Will need some error handling in `wikiapi.js` – #267 )

The user’s choice for any given "page" (eg: `User:Verification_pages_bot/verification/ca`) is stored in the browser’s LocalStorage, so it’ll persist between page reloads.

![language-small](https://user-images.githubusercontent.com/739624/42695145-5f6fa5fa-86ac-11e8-9db7-7aa1a96e5198.gif)
