### PR TITLE
Avoid adding incorrect qualifiers to executive positions

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,7 +78,7 @@ class PagesController < ApplicationController
     params.require(:page).permit(:title, :position_held_item,
                                  :parliamentary_term_item, :reference_url,
                                  :require_parliamentary_group, :country_id,
-                                 :csv_source_url)
+                                 :csv_source_url, :executive_position)
   end
 
   def new_page_params

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -18,9 +18,9 @@ class StatementDecorator < SimpleDelegator
   def matches_wikidata?
     reconciled? &&
       person_matches? &&
-      electoral_district_item.present? && electoral_district_item == data&.district &&
-      parliamentary_term_item.present? && parliamentary_term_item == data&.term &&
-      (parliamentary_group_item.blank? || parliamentary_group_item == data&.group)
+      electoral_district_matches? &&
+      parliamentary_term_matches? &&
+      parliamentary_group_matches?
   end
 
   def matches_but_not_checked?
@@ -120,5 +120,17 @@ class StatementDecorator < SimpleDelegator
 
   def person_matches?
     person_item.present? && ([data&.person] + merged_then_deleted).include?(person_item)
+  end
+
+  def electoral_district_matches?
+    electoral_district_item.present? && electoral_district_item == data&.district
+  end
+
+  def parliamentary_term_matches?
+    parliamentary_term_item.present? && parliamentary_term_item == data&.term
+  end
+
+  def parliamentary_group_matches?
+    parliamentary_group_item.blank? || parliamentary_group_item == data&.group
   end
 end

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -132,6 +132,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def parliamentary_group_matches?
+    return true if page.executive_position?
     parliamentary_group_item.blank? || parliamentary_group_item == data&.group
   end
 end

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -123,6 +123,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def electoral_district_matches?
+    return true if page.executive_position?
     electoral_district_item.present? && electoral_district_item == data&.district
   end
 

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -52,7 +52,7 @@ export default template({
         qualifiers[wikidataClient.getPropertyID('parliamentary group')] =
           this.statement.parliamentary_group_item;
       }
-      if (this.statement.electoral_district_item) {
+      if (!this.page.executive_position && this.statement.electoral_district_item) {
         qualifiers[wikidataClient.getPropertyID('electoral district')] =
           this.statement.electoral_district_item;
       }

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -48,7 +48,7 @@ export default template({
         value: this.statement.verified_on, type: 'time'
       }
 
-      if (this.statement.parliamentary_group_item) {
+      if (!this.page.executive_position && this.statement.parliamentary_group_item) {
         qualifiers[wikidataClient.getPropertyID('parliamentary group')] =
           this.statement.parliamentary_group_item;
       }

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -62,6 +62,11 @@
     <%= f.label :require_parliamentary_group, class: 'form-check-label' %>
     <%= f.error_span(:require_parliamentary_group) %>
   </div>
+  <div class="form-check">
+    <%= f.check_box :executive_position %>
+    <%= f.label :executive_position, class: 'form-check-label' %>
+    <%= f.error_span(:executive_position) %>
+  </div>
 
   <div class="form-group">
     <div class="col-lg-offset-2 col-lg-10">

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -13,6 +13,7 @@
       <th><%= model_class.human_attribute_name(:reference_url) %></th>
       <th><%= model_class.human_attribute_name(:csv_source_url) %></th>
       <th><%= model_class.human_attribute_name(:require_parliamentary_group) %></th>
+      <th><%= model_class.human_attribute_name(:executive_position) %></th>
       <th><%= t '.actions', default: t("helpers.actions") %></th>
     </tr>
   </thead>
@@ -27,6 +28,7 @@
         <td><%= page.reference_url %></td>
         <td><%= page.csv_source_url %></td>
         <td><%= page.require_parliamentary_group %></td>
+        <td><%= page.executive_position %></td>
         <td>
           <%= link_to t('.show', default: t("helpers.links.show")),
                       page_path(page), class: 'btn btn-default btn-xs' %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -22,6 +22,8 @@
   <dd><%= link_to @page.country.name, @page.country %></dd>
   <dt><strong><%= model_class.human_attribute_name(:require_parliamentary_group) %>:</strong></dt>
   <dd><%= @page.require_parliamentary_group %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:executive_position) %>:</strong></dt>
+  <dd><%= @page.executive_position %></dd>
   <dt><strong>Statements</strong></dt>
   <dd><%= @page.statements.count %></dd>
 </dl>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -26,6 +26,6 @@ json.statements @classifier.to_a do |statement|
   end
 end
 
-json.page @classifier.page, :reference_url, :position_held_item
+json.page @classifier.page, :reference_url, :position_held_item, :executive_position
 
 json.country @classifier.page.country

--- a/db/migrate/20180717102517_add_executive_position_to_pages.rb
+++ b/db/migrate/20180717102517_add_executive_position_to_pages.rb
@@ -1,0 +1,5 @@
+class AddExecutivePositionToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :executive_position, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180710103915) do
+ActiveRecord::Schema.define(version: 2018_07_17_102517) do
 
-  create_table "countries", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.string "code"
     t.string "description_en"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20180710103915) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.string "position_held_item", null: false
     t.string "parliamentary_term_item"
@@ -32,10 +32,11 @@ ActiveRecord::Schema.define(version: 20180710103915) do
     t.datetime "updated_at", null: false
     t.bigint "country_id", null: false
     t.string "csv_source_url", limit: 2000, null: false
+    t.boolean "executive_position", default: false, null: false
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 
-  create_table "reconciliations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "reconciliations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "statement_id"
     t.string "item"
     t.string "user"
@@ -45,7 +46,7 @@ ActiveRecord::Schema.define(version: 20180710103915) do
     t.index ["statement_id"], name: "index_reconciliations_on_statement_id"
   end
 
-  create_table "statements", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "statements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "transaction_id"
     t.string "person_item"
     t.string "person_revision"
@@ -66,7 +67,7 @@ ActiveRecord::Schema.define(version: 20180710103915) do
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 
-  create_table "verifications", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "verifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "statement_id", null: false
     t.boolean "status", default: false
     t.string "user", null: false

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PagesController, type: :controller do
   let(:valid_attributes) do
     { title: 'Page title', position_held_item: 'Q1',
       parliamentary_term_item: 'Q2', reference_url: 'http://example.com',
-      country_id: country.id, csv_source_url: 'http://example.com/export.csv' }
+      country_id: country.id, csv_source_url: 'http://example.com/export.csv', executive_position: false }
   end
 
   let(:invalid_attributes) do

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -364,5 +364,30 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.done).to eq(statements) }
       it { expect(classifier.reverted).to be_empty }
     end
+
+    context "when the Wikidata item has no group and the statement's page has executive_position = true set" do
+      let(:page) do
+        build(:page, parliamentary_term_item: 'Q2', executive_position: true)
+      end
+      let(:wikidata_data) do
+        { person: 'Q1',
+          merged_then_deleted: '',
+          term: 'Q2',
+          term_start: '2018-01-01',
+          position_start: '2018-01-01',
+          group: nil,
+          district: 'Q4' }
+      end
+      before do
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
+    end
   end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -339,5 +339,30 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.done).to eq(statements) }
       it { expect(classifier.reverted).to be_empty }
     end
+
+    context "when the Wikidata item has no district and the statement's page has executive_position = true set" do
+      let(:page) do
+        build(:page, parliamentary_term_item: 'Q2', executive_position: true)
+      end
+      let(:wikidata_data) do
+        { person: 'Q1',
+          merged_then_deleted: '',
+          term: 'Q2',
+          term_start: '2018-01-01',
+          position_start: '2018-01-01',
+          group: 'Q3',
+          district: nil }
+      end
+      before do
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
+    end
   end
 end


### PR DESCRIPTION
This adds an `executive_position` boolean column to the `pages` table. This is then checked in the javascript when we're building up a list of qualifiers and if it's `true` then we skip adding the electoral district and parliamentary group qualifiers, which doesn't make sense on executive positions. It also changes `StatementDecorator` to ignore districts and group qualifiers when matching executive positions to Wikidata.

Fixes #277 
Fixes https://github.com/mysociety/verification-pages/issues/285

<img width="504" alt="screen shot 2018-07-17 at 11 43 59" src="https://user-images.githubusercontent.com/22996/42812802-b988b484-89b6-11e8-9d78-1c034a8ad739.png">