### PR TITLE
Skip verification of non-suggestions-store data that's already correct

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -15,12 +15,20 @@ class StatementDecorator < SimpleDelegator
     matching_position_held_data.first
   end
 
-  def done?
-    verified? && reconciled? &&
+  def matches_wikidata?
+    reconciled? &&
       person_matches? &&
       electoral_district_item.present? && electoral_district_item == data&.district &&
       parliamentary_term_item.present? && parliamentary_term_item == data&.term &&
       (parliamentary_group_item.blank? || parliamentary_group_item == data&.group)
+  end
+
+  def matches_but_not_checked?
+    latest_verification.nil? && matches_wikidata?
+  end
+
+  def done?
+    verified? && matches_wikidata?
   end
 
   def problems

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -88,6 +88,8 @@ class StatementClassifier
       :reconcilable
     elsif statement.unverifiable?
       :unverifiable
+    elsif !statement.from_suggestions_store? && statement.matches_but_not_checked?
+      :done
     else
       :verifiable
     end


### PR DESCRIPTION
When data comes from suggestions-store, it's important for us to check
whether it's correct, regardless of whether Wikidata already has that
information, so that our partner have a signal about whether individual
crowd-sourcers are performing well or not, and because we only allow
data through to their build which has been verified.

However, for external sources, where we're just using a verification
page to make sure the country is up-to-date, you usually would want to
completely skip over those cases since nothing needs to be done,
except possibly adding a reference URL.

Tony Bowden pointed out that we might want this to be a new state
("matches but not checked") so that people can go through those to add
the reference URLs, but will require updating the UI, and this is a good
first step towards that. (Essentially the same elsif clause can be used
to define that new state.)

Fixes #181