### PR TITLE
Allow position start data up to a month before term start date

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -41,7 +41,7 @@ class StatementDecorator < SimpleDelegator
 
   def start_date_before_term_problems
     return [] unless data&.position_start && data&.term_start &&
-      Date.parse(data.position_start) < Date.parse(data.term_start) - 1.day
+      Date.parse(data.position_start) < Date.parse(data.term_start) - 31.days
     [ "On Wikidata, the position held start date (#{data&.position_start}) was before the term start date (#{data&.term_start})" ]
   end
 

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -78,19 +78,19 @@ RSpec.describe StatementDecorator, type: :decorator do
       end
     end
 
-    context 'when the position start date on Wikidata is more than 1 day before the start of the term' do
+    context 'when the position start date on Wikidata is more than 31 days before the start of the term' do
       let(:matching_position_held_data) do
         [
           OpenStruct.new(
             revision: '123',
             position: 'UUID',
-            position_start: '2014-01-06',
+            position_start: '2013-12-15',
             term_start: '2014-01-31'
           )
         ]
       end
       let(:expected_error) do
-        'On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)'
+        'On Wikidata, the position held start date (2013-12-15) was before the term start date (2014-01-31)'
       end
       it 'should find a problem with the start date' do
         expect(statement.start_date_before_term_problems).to eq([ expected_error ])
@@ -151,7 +151,7 @@ RSpec.describe StatementDecorator, type: :decorator do
           OpenStruct.new(
             revision: '123',
             position: 'UUID',
-            position_start: '2014-01-06',
+            position_start: '2013-12-15',
             term_start: '2014-01-31',
             district: 'Q345',
             group: 'Q234'
@@ -163,7 +163,7 @@ RSpec.describe StatementDecorator, type: :decorator do
         expected_errors = [
           "The electoral district is different in the statement (Q789) and on Wikidata (Q345)",
           "The parliamentary group (party) is different in the statement (Q123) and on Wikidata (Q234)",
-          "On Wikidata, the position held start date (2014-01-06) was before the term start date (2014-01-31)",
+          "On Wikidata, the position held start date (2013-12-15) was before the term start date (2014-01-31)",
           'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
         ]
         expect(statement.problems).to eq(expected_errors)

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -214,10 +214,10 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.reverted).to be_empty }
     end
 
-    context 'when position start is 2 days before term start' do
+    context 'when position start is more than 31 days before term start' do
       before do
         position_held.group = nil
-        position_held.position_start = '2017-12-30'
+        position_held.position_start = '2017-11-05'
         allow(statement).to receive(:person_item).and_return('Q1')
       end
       it { expect(classifier.verifiable).to be_empty }


### PR DESCRIPTION
2a9a8743a34d75afa previously returned statements from the Wikidata Query
Service even if the position start date was up to roughly 4 weeks before
the start of the term (to accommodate the common situation where
politicians aren't formally inaugurated until some time after the
election, or the term has begun). However, if it was more than one day
before the term start date they were still being put into the
manually_actionable state. This commit changes the detection of this
problem so that the statement only goes into manually_actionable if the
position start_date is more than 31 days before the start of the term.

Fixes #297