### PR TITLE
Don't compare district information if it's not provided in the source

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -18,7 +18,7 @@ class StatementDecorator < SimpleDelegator
   def matches_wikidata?
     reconciled? &&
       person_matches? &&
-      electoral_district_matches? &&
+      (electoral_district_item.blank? || electoral_district_matches?) &&
       parliamentary_term_matches? &&
       parliamentary_group_matches?
   end
@@ -46,6 +46,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def electoral_district_problems
+    return [] unless electoral_district_item.present?
     return [] unless data&.district && electoral_district_item != data&.district
     [ "The electoral district is different in the statement (#{electoral_district_item}) and on Wikidata (#{data&.district})" ]
   end

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe StatementDecorator, type: :decorator do
-  let(:object) { Statement.new(person_item: 'Q1') }
+  let(:object) { build(:statement, person_item: 'Q1') }
   let(:matching_position_held_data) do
     [ OpenStruct.new(revision: '123', position: 'UUID') ]
   end
@@ -38,7 +38,8 @@ RSpec.describe StatementDecorator, type: :decorator do
 
     context 'when electoral districts contradict' do
       let(:object) do
-        Statement.new(
+        build(
+          :statement,
           person_item: 'Q1',
           electoral_district_item: 'Q789',
         )
@@ -59,7 +60,8 @@ RSpec.describe StatementDecorator, type: :decorator do
 
     context 'when parliamentary groups (parties) contradict' do
       let(:object) do
-        Statement.new(
+        build(
+          :statement,
           person_item: 'Q1',
           parliamentary_group_item: 'Q123',
         )
@@ -140,7 +142,8 @@ RSpec.describe StatementDecorator, type: :decorator do
 
     context 'when all known problems happen for the same data' do
       let(:object) do
-        Statement.new(
+        build(
+          :statement,
           person_item: 'Q1',
           parliamentary_group_item: 'Q123',
           electoral_district_item: 'Q789',

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StatementDecorator, type: :decorator do
 
     context 'when electoral districts contradict' do
       let(:object) do
-        build(
+        create(
           :statement,
           person_item: 'Q1',
           electoral_district_item: 'Q789',
@@ -142,7 +142,7 @@ RSpec.describe StatementDecorator, type: :decorator do
 
     context 'when all known problems happen for the same data' do
       let(:object) do
-        build(
+        create(
           :statement,
           person_item: 'Q1',
           parliamentary_group_item: 'Q123',
@@ -170,6 +170,32 @@ RSpec.describe StatementDecorator, type: :decorator do
           'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
         ]
         expect(statement.problems).to eq(expected_errors)
+      end
+    end
+
+    context 'when a source contains no district information' do
+      let(:object) do
+        build(
+          :statement,
+          person_item: 'Q1',
+          parliamentary_group_item: 'Q123',
+          electoral_district_name: 'Somewhereville'
+        )
+      end
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision: '123',
+            position: 'UUID',
+            position_start: '2014-01-31',
+            term_start: '2014-01-31',
+            district: 'Q345',
+            group: 'Q123'
+          ),
+        ]
+      end
+      it 'should not report any problems with district' do
+        expect(statement.problems).to eq([])
       end
     end
   end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -389,5 +389,32 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.done).to eq(statements) }
       it { expect(classifier.reverted).to be_empty }
     end
+
+    context 'when statement has no district but Wikidata does and everything else matches' do
+      let(:page) do
+        build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')
+      end
+      let(:data) do
+        { person_item: 'Q1',
+          parliamentary_group_item: 'Q3',
+          electoral_district_item: nil }
+      end
+      let(:wikidata_data) do
+        { person: 'Q1',
+          merged_then_deleted: '',
+          term: 'Q2',
+          term_start: '2018-01-01',
+          position_start: '2018-01-01',
+          group: 'Q3',
+          district: 'Q4' }
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
+    end
   end
 end


### PR DESCRIPTION
This adds a check to ignore any problems with `electoral_district_item` if that data wasn't provided in the source CSV. Previously it would have complained that the source didn't match Wikidata, but if none of the statements in the source have the district then it doesn't make sense to try and compare it.

Part of #238 