### PR TITLE
Basic support for reconciling districts

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -88,7 +88,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def reconciliations
-    person_reconciliations + party_reconciliations
+    person_reconciliations + party_reconciliations + district_reconciliations
   end
 
   def person_reconciliations
@@ -100,6 +100,11 @@ class StatementDecorator < SimpleDelegator
     return [] if !page.require_parliamentary_group? ||
       parliamentary_group_item.present?
     [ 'party' ]
+  end
+
+  def district_reconciliations
+    return [] if electoral_district_item.present? || !electoral_district_name.present?
+    [ 'district' ]
   end
 
   def verified_on

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -2,6 +2,7 @@
   <span v-if="!searchResultsLoading && !searchResultsLoaded">
     <button v-if="statement.reconciliations.indexOf('person') != -1" v-on:click="searchForName()" class="mw-ui-button mw-ui-progressive">Search for person</button>
     <button v-if="statement.reconciliations.indexOf('party') != -1" v-on:click="searchForParty()" class="mw-ui-button mw-ui-progressive">Search for party</button>
+    <button v-if="statement.reconciliations.indexOf('district') != -1" v-on:click="searchForDistrict()" class="mw-ui-button mw-ui-progressive">Search for district</button>
   </span>
   <span v-if="searchResultsLoading">
     Loading search results...

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -29,6 +29,10 @@ export default template({
       this.searchResourceType = 'party'
       this.search(this.statement.parliamentary_group_name)
     },
+    searchForDistrict: function () {
+      this.searchResourceType = 'district'
+      this.search(this.statement.electoral_district_name)
+    },
     search: function (searchTerm) {
       this.searchResultsLoaded = false;
       this.searchResultsLoading = true;

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -18,6 +18,8 @@ class Reconciliation < ApplicationRecord
       statement.update_attributes(person_item: item)
     when 'party'
       statement.update_attributes(parliamentary_group_item: item)
+    when 'district'
+      statement.update_attributes(electoral_district_item: item)
     end
   end
 

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -216,6 +216,27 @@ RSpec.describe StatementDecorator, type: :decorator do
       it { is_expected.to match_array(%w[person]) }
     end
 
+    context 'when the district has been reconciled' do
+      before { statement.electoral_district_item = 'Q123' }
+      it { is_expected.to match_array([]) }
+    end
+
+    context 'when the district hasn\'t be reconciled but there was no name to reconcile' do
+      before do
+        statement.electoral_district_item = nil
+        statement.electoral_district_name = nil
+      end
+      it { is_expected.to match_array([]) }
+    end
+
+    context 'when the district hasn\'t be reconciled but there was a name to reconcile' do
+      before do
+        statement.electoral_district_item = nil
+        statement.electoral_district_name = 'Cambridge'
+      end
+      it { is_expected.to match_array(%w[district]) }
+    end
+
     context 'when page does not require a party' do
       before { page.require_parliamentary_group = false }
 

--- a/spec/models/reconciliation_spec.rb
+++ b/spec/models/reconciliation_spec.rb
@@ -61,5 +61,21 @@ RSpec.describe Reconciliation, type: :model do
         reconciliation.save! # update
       end
     end
+
+    context 'district resource_type' do
+      before { reconciliation.resource_type = 'district' }
+
+      it 'updates statement electoral district item' do
+        expect(statement).to receive(:update_attributes)
+          .with(electoral_district_item: 'Q5').once
+        reconciliation.item = 'Q5'
+        reconciliation.save! # create
+
+        expect(statement).to receive(:update_attributes)
+          .with(electoral_district_item: 'Q6').once
+        reconciliation.item = 'Q6'
+        reconciliation.save! # update
+      end
+    end
   end
 end


### PR DESCRIPTION
This is very similar to the changes in:

  073d8b932680343567e63c5369c2581a72d7d14b
  6a7806b3b2acd82a772f6042a9ca0d74eef67ab7
  6ec170d9e2eb8e94d8a0b08284f09e8a3f1fbfaf
  fe893cbe1cbb7c948c124c8084b188f75f26d8e9
  a65b8bd3a35c0689a981d8e4d66d75a9db4a6d84

... which added support for reconciling parties, but this commit adds
support for reconciling districts.

(This doesn't add a "Create new item" button, so the districts have to
exist in Wikidata already, but we can add that later.)

Fixes #292