### PR TITLE
Stop periodically wiping out reconciled values, and add a script for restoring them

### DIFF
--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -16,14 +16,20 @@ class LoadStatements < ServiceBase
         transaction_id: result[:transaction_id]
       )
 
+      # We need to be careful not wipe out any manually reconciled
+      # items when refreshing from the upstream CSV file, so don't
+      # overwrite the *_item attributes if that'd make them blank:
+      %i[person_item electoral_district_item parliamentary_group_item].each do |item_attribute|
+        if result[item_attribute].present?
+          statement.public_send("#{item_attribute}=", result[item_attribute])
+        end
+      end
+      # The other attributes we always update from the upstream CSV:
       statement.update_attributes!(
         page: page,
         person_name: result[:person_name],
-        person_item: result[:person_item],
         electoral_district_name: result[:electoral_district_name],
-        electoral_district_item: result[:electoral_district_item],
         parliamentary_group_name: result[:parliamentary_group_name],
-        parliamentary_group_item: result[:parliamentary_group_item],
         fb_identifier: result[:fb_identifier]
       )
     end

--- a/lib/tasks/restore_reconciliations.rake
+++ b/lib/tasks/restore_reconciliations.rake
@@ -1,0 +1,11 @@
+desc 'Restore reconciled item IDs on statements from the reconciliations table'
+task restore_reconciliations: :environment do
+  # Touching each reconciliation should trigger the `after_commit`
+  # callback, which updates the statement to set the reconciled item
+  # value. We want to do this in the order they were created -
+  # fortunately, find_each orders on the primary key, so this should
+  # be the case.
+  Reconciliation.find_each do |reconciliation|
+    reconciliation.touch
+  end
+end


### PR DESCRIPTION
If someone does a manual reconciliation on a Verification Page, then
that sets the person_item on that Statement. However, when the cron job
runs to update statements from the CSV source, the blank value from the
CSV file would overwrite person_item, losing the good work they'd done
and putting the statement into a confusing state. (We're also moving to
reconciling parliamentary groups and electoral districts, so the same
concern applies the reconciled values for them too.)

The first commit here changes LoadStatements.run so that it only
updates *_item attributes if there's actually a value for them in the CSV file.

The second commit adds a rake task to restore the items that were lost
by this bug.

Fixes #305 