### PR TITLE
Make 'title', not 'position_held_item' the unique column on pages

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,9 +5,8 @@ class Page < ApplicationRecord
   has_many :statements, dependent: :destroy
   belongs_to :country
 
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
   validates :position_held_item, presence: true
-  validates :parliamentary_term_item, uniqueness: { allow_blank: true }
   validates :reference_url, presence: true
   validates :csv_source_url, presence: true
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
+  sequence :title do |n|
+    "Test page #{n}"
+  end
   factory :page do
-    title 'Test page'
+    title
     position_held_item 'Q1'
     reference_url 'http://example.com'
     csv_source_url 'https://example.com/export.csv'

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe StatementsStatistics do
   describe '#statistics' do
+    let! (:page) { create(:page, position_held_item: 'Q15964890') }
     before do
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/countries.json')
         .to_return(body: '[{"code": "ca", "export_json_url": "https://suggestions-store.mysociety.org/export/ca.json"}]')
@@ -24,7 +25,6 @@ describe StatementsStatistics do
       ]
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
         .to_return(body: JSON.generate(body))
-      create(:page, position_held_item: 'Q15964890')
     end
     it 'returns a hash of country stats' do
       statement_statistics = StatementsStatistics.new
@@ -33,7 +33,7 @@ describe StatementsStatistics do
       expect(position_stats.correct).to eq(2)
       expect(position_stats.incorrect).to eq(1)
       expect(position_stats.unchecked).to eq(0)
-      expect(position_stats.pages).to eq(['Test page'])
+      expect(position_stats.pages).to eq([page.title])
     end
   end
 end


### PR DESCRIPTION
It turns out to be useful to be able to create multiple verification
pages, with different sources, for a single term of a particular
parliament. (e.g. you might have one from a scraper of the official
site, and another for a scraper of the Wikipedia page.)

This was being prevented, however, by the Page model having a uniqueness
constraint on 'position_held_item'. This commit changes the uniqueness
constraint on that model to be on 'title' instead. This makes sense
since the rest of the code already treats 'title' as a unique key for
the table (e.g. when the frontend Javascript fetches statements for a
page, it does it using the page title, not the position_held_item.)

Fixes #325