### PR TITLE
Replace the transaction ID with a link to the statement

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -32,7 +32,6 @@ $color_pale_grey: #eee;
 .verification-tool__table {
     width: 100%;
     border-collapse: collapse;
-    table-layout: fixed;
 
     td {
         padding: 1em;
@@ -51,6 +50,10 @@ $color_pale_grey: #eee;
             font-size: inherit;
             text-align: right;
         }
+    }
+
+    tr:target {
+        animation: background-yellow-to-white 5s 1;
     }
 }
 
@@ -89,10 +92,27 @@ $color_pale_grey: #eee;
   }
 }
 
+@keyframes background-yellow-to-white {
+  0%, 50% {
+    background: #ffffcc;
+  }
+  100% {
+    background: #ffffff;
+  }
+}
+
 .verification-tool__table__cell-label {
     font-size: 0.8em;
     font-weight: bold;
     display: block;
+}
+
+.verification-tool__table__cell-link {
+    padding: 0.5em;
+}
+
+.verification-tool__table__cell--narrow {
+    width: 0;
 }
 
 .verification-tool__controls {

--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -52,7 +52,7 @@ $color_pale_grey: #eee;
         }
     }
 
-    tr:target {
+    tr:target, .targetted {
         animation: background-yellow-to-white 5s 1;
     }
 }

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -47,7 +47,7 @@
   <div v-if="loaded && currentStatements.length > 0">
     <table class="verification-tool__table">
       <tbody v-for="statement in currentStatements">
-      <tr>
+      <tr :id="'s:' + statement.transaction_id">
         <td>
           <span class="verification-tool__table__cell-label">Subject</span>
           <wikilink :id="statement.person_item">{{ statement.person_name }}</wikilink>
@@ -60,9 +60,8 @@
           <span class="verification-tool__table__cell-label">Parliamentary group</span>
           <wikilink :id="statement.parliamentary_group_item">{{ statement.parliamentary_group_name || '&nbsp;' }}</wikilink>
         </td>
-        <td>
-          <span class="verification-tool__table__cell-label">Transaction ID</span>
-          {{ statement.transaction_id }}
+        <td class="verification-tool__table__cell--narrow">
+          <a class="verification-tool__table__cell-link" :href="'#s:' + statement.transaction_id" title="Link to this statement">§</a>
         </td>
       </tr>
       <tr>

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -40,6 +40,15 @@ export default template({
         this.statements.splice(index, 1, newStatement)
       }).then(cb)
     })
+    this.$on('statements-loaded', () => {
+      this.$nextTick(function () {
+        var statementRow = document.querySelector(window.location.hash.replace(/:/g, '\\:'))
+        if (statementRow) {
+          statementRow.scrollIntoView()
+          statementRow.className += " targetted"
+        }
+      })
+    })
   },
   methods: {
     loadStatements: function () {
@@ -51,6 +60,7 @@ export default template({
         this.country = response.data.country
       }).then(() => {
         this.loaded = true
+        this.$emit('statements-loaded')
       })
     },
     countStatementsOfType: function (type) {


### PR DESCRIPTION
This has the advantage of simplifying the interface and also adding a useful feature - you can now link directly to a statement.

![image](https://user-images.githubusercontent.com/7907/43072504-333a15c8-8e6e-11e8-94b1-917592c03325.png)

Fixes #318 (and incidentally fixes #152)
