### PR TITLE
Additional reference URL qualifiers

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,7 +78,8 @@ class PagesController < ApplicationController
     params.require(:page).permit(:title, :position_held_item,
                                  :parliamentary_term_item, :reference_url,
                                  :require_parliamentary_group, :country_id,
-                                 :csv_source_url, :executive_position)
+                                 :csv_source_url, :executive_position,
+                                :reference_url_title, :reference_url_language)
   end
 
   def new_page_params

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import ENV from '../env'
 import Axios from 'axios'
-import wikidataClient from '../wikiapi'
+import wikidataClient, { getItemValue } from '../wikiapi'
 import template from './actionable.html'
 import StatementChangeSummary from './statement_change_summary'
 
@@ -46,6 +46,20 @@ export default template({
 
       references[wikidataClient.getPropertyID('reference retrieved')] = {
         value: this.statement.verified_on, type: 'time'
+      }
+
+      if (this.page.reference_url_title) {
+        references[wikidataClient.getPropertyID('title')] = {
+          value: this.page.reference_url_title,
+          type: 'string'
+        };
+      }
+
+      if (this.page.reference_url_language) {
+        references[wikidataClient.getPropertyID('language of work or name')] = {
+          value: getItemValue(this.page.reference_url_language),
+          type: 'wikibase-entityid'
+        };
       }
 
       if (!this.page.executive_position && this.statement.parliamentary_group_item) {

--- a/app/javascript/components/statement_change_summary.html
+++ b/app/javascript/components/statement_change_summary.html
@@ -18,6 +18,18 @@
   </li>
   <li>'reference URL' qualifier:
     <a target="_blank" rel="noopener nofollow" class="external free" :href="page.reference_url">{{ page.reference_url }}</a>
+    <ul v-if="page.reference_url_title || page.reference_url_language">
+      <li v-if="page.reference_url_title">
+        'title' qualifier:
+        {{ page.reference_url_title }}
+      </li>
+      <li v-if="page.reference_url_language">
+        'language of work or name' qualifier:
+        <wikilink :id="page.reference_url_language">
+          {{ page.reference_url_language }}
+        </wikilink>
+      </li>
+    </ul>
   </li>
   <li>'reference retrieved' qualifier:
     {{ statement.verified_on }}

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -9,7 +9,7 @@ function lowerCaseSnak(upperCase) {
   return parts[0] + '$' + parts[1].toLowerCase();
 }
 
-function getItemValue(item) {
+export function getItemValue(item) {
   return {'entity-type': 'item', 'numeric-id': Number(item.substring(1))};
 }
 
@@ -450,6 +450,8 @@ var wikidata = function(spec) {
         'electoral district': 'P768',
         'position held': 'P39',
         'parliamentary term': 'P2937',
+        'title': 'P1476',
+        'language of work or name': 'P407',
       },
       'test.wikidata.org': {
         'reference URL': 'P43659',
@@ -460,6 +462,8 @@ var wikidata = function(spec) {
         'electoral district': 'P70558',
         'position held': 'P39',
         'parliamentary term': 'P70901',
+        'title': 'P95',
+        'language of work or name': 'P77090',
       },
       'localhost': {
         // For local development assume we're using test.wikidata for
@@ -474,6 +478,8 @@ var wikidata = function(spec) {
         'electoral district': 'P70558',
         'position held': 'P39',
         'parliamentary term': 'P70901',
+        'title': 'P95',
+        'language of work or name': 'P77090',
       }
     }
     if (!(that.serverName in knownPropertiesByServer)) {

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -44,6 +44,20 @@
     <%= f.error_span(:reference_url) %>
   </div>
   <div class="form-group">
+    <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :reference_url_title, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:reference_url_title) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :reference_url_language, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :reference_url_language, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:reference_url_language) %>
+  </div>
+  <div class="form-group">
     <%= f.label :csv_source_url, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.text_field :csv_source_url, class: 'form-control' %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -16,6 +16,10 @@
   <dd><%= @page.parliamentary_term_item %></dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= @page.reference_url %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:reference_url_title) %>:</strong></dt>
+  <dd><%= @page.reference_url_title %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:reference_url_language) %>:</strong></dt>
+  <dd><%= @page.reference_url_language %></dd>
   <dt><strong><%= model_class.human_attribute_name(:csv_source_url) %>:</strong></dt>
   <dd><%= @page.csv_source_url %></dd>
   <dt><strong><%= model_class.human_attribute_name(:country_id) %>:</strong></dt>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -26,6 +26,6 @@ json.statements @classifier.to_a do |statement|
   end
 end
 
-json.page @classifier.page, :reference_url, :position_held_item, :executive_position
+json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language
 
 json.country @classifier.page.country

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,5 +39,7 @@ en:
         position_held_item: Position
         parliamentary_term_item: Term
         reference_url: Reference URL
+        reference_url_title: Reference URL title
+        reference_url_language: Reference URL language
         csv_source_url: CSV source URL
         require_parliamentary_group: Party required

--- a/db/migrate/20180723140444_add_reference_url_title_and_language_to_page.rb
+++ b/db/migrate/20180723140444_add_reference_url_title_and_language_to_page.rb
@@ -1,0 +1,6 @@
+class AddReferenceUrlTitleAndLanguageToPage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :reference_url_title, :string
+    add_column :pages, :reference_url_language, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_17_102517) do
+ActiveRecord::Schema.define(version: 2018_07_23_140444) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 2018_07_17_102517) do
     t.bigint "country_id", null: false
     t.string "csv_source_url", limit: 2000, null: false
     t.boolean "executive_position", default: false, null: false
+    t.string "reference_url_title"
+    t.string "reference_url_language"
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe PagesController, type: :controller do
   let(:valid_attributes) do
     { title: 'Page title', position_held_item: 'Q1',
       parliamentary_term_item: 'Q2', reference_url: 'http://example.com',
-      country_id: country.id, csv_source_url: 'http://example.com/export.csv', executive_position: false }
+      country_id: country.id, csv_source_url: 'http://example.com/export.csv', executive_position: false,
+      reference_url_title: 'Example site', reference_url_language: 'en' }
   end
 
   let(:invalid_attributes) do


### PR DESCRIPTION
This adds a `reference_url_title` and `reference_url_language` fields to the pages table, and then if set uses them for the `title` and `language of work or name` qualifiers on the reference URL.

Fixes #175 

![image](https://user-images.githubusercontent.com/22996/43086053-60bcf21a-8e94-11e8-92c2-f69ca2b95288.png)
