### PR TITLE
Fix typo of "statement statement"

### DIFF
--- a/app/javascript/components/reverted.html
+++ b/app/javascript/components/reverted.html
@@ -1,3 +1,3 @@
 <span>
-  This statement statement was actioned, but has since been changed on Wikidata
+  This statement was actioned, but has since been changed on Wikidata
 </span>


### PR DESCRIPTION
"This statement statement was actioned" should be "This statement was actioned".

Fixes #237