### PR TITLE
Allow custom search term during reconciliation

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -44,10 +44,13 @@ $color_pale_grey: #eee;
             margin: 0 0.5em;
         }
 
-        .language-chooser {
-            width: 3em;
+        input {
             font-weight: inherit;
             font-size: inherit;
+        }
+
+        .language-chooser {
+            width: 3em;
             text-align: right;
         }
     }

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -5,25 +5,27 @@
     <button v-if="statement.reconciliations.indexOf('district') != -1" v-on:click="searchForDistrict()" class="mw-ui-button mw-ui-progressive">Search for district</button>
   </span>
   <span v-else>
-    <span v-if="this.searchResourceType === 'person'">
-      <h3>Create a new item</h3>
-      <button v-on:click="createPerson()" class="mw-ui-button">Create {{ statement.person_name }}</button>
-    </span>
-    <h3>Wikidata search results</h3>
-    <ul class="wd-search-results">
+    <h3>
+      Results for
+      <input v-model="searchTerm" type="search">
+      from Wikidata and
+      <input v-model="languageCode" class="language-chooser">.wikipedia.org
+      <button v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Update results</button>
+    </h3>
+    <ul class="wp-search-results">
       <li v-for="wdResult in searchResults.fromWikidata">
         <button v-on:click="reconcileWithItem(wdResult.item)" class="mw-ui-button">Use this</button>
         <span class="item-from-search">{{ wdResult.item }}</span>
         <a target="_blank" rel="noopener nofollow" class="external free" :href="wdResult.url">{{ wdResult.label }} ({{ wdResult.description }})</a>
       </li>
-    </ul>
-    <h3><input v-if="languageChooserActive" v-model="languageCode" class="language-chooser"><span v-else>{{ languageCode }}</span>.wikipedia.org search results <button v-on:click="toggleLanguageChooser()" v-if="!languageChooserActive" class="mw-ui-button">Choose a different Wikipedia</button><button v-else v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Update results</button></h3>
-    <ul class="wp-search-results">
       <li v-for="wpResult in searchResults.fromWikipedia">
         <button v-on:click="reconcileWithItem(wpResult.item)" class="mw-ui-button">Use this</button>
         <span class="item-from-search">{{ wpResult.item }}</span>
         <a target="_blank" rel="noopener nofollow" class="external free" :href="wpResult.wpURL">{{ wpResult.title }} </a>
         <div v-html="wpResult.snippetHTML"></div>
+      </li>
+      <li v-if="this.searchResourceType === 'person'">
+        <button v-on:click="createPerson()" class="mw-ui-button">Create new item: {{ searchTerm }}</button>
       </li>
     </ul>
   </span>

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -5,10 +5,10 @@ import template from './reconcilable.html'
 
 export default template({
   data () { return {
+    searchTerm: null,
     searchResults: null,
     searchResourceType: null,
-    languageCode: 'en',
-    languageChooserActive: false
+    languageCode: 'en'
   } },
   props: ['statement', 'page', 'country'],
   created: function () {
@@ -17,15 +17,24 @@ export default template({
   methods: {
     searchForName: function () {
       this.searchResourceType = 'person'
-      this.search(this.statement.person_name)
+      if (!this.searchTerm) {
+        this.searchTerm = this.statement.person_name
+      }
+      this.search(this.searchTerm)
     },
     searchForParty: function () {
       this.searchResourceType = 'party'
-      this.search(this.statement.parliamentary_group_name)
+      if (!this.searchTerm) {
+        this.searchTerm = this.statement.parliamentary_group_name
+      }
+      this.search(this.searchTerm)
     },
     searchForDistrict: function () {
       this.searchResourceType = 'district'
-      this.search(this.statement.electoral_district_name)
+      if (!this.searchTerm) {
+        this.searchTerm = this.statement.electoral_district_name
+      }
+      this.search(this.searchTerm)
     },
     search: function (searchTerm) {
       this.$parent.$emit('loading', 'Loading search results')
@@ -61,18 +70,12 @@ export default template({
         this.reconcileWithItem(createdItemData.item);
       })
     },
-    toggleLanguageChooser: function () {
-      this.languageChooserActive = !this.languageChooserActive;
-    },
     changeLanguage: function () {
-      this.languageChooserActive = false;
       localStorage.setItem(wikidataClient.page + '.language', this.languageCode);
-
-      if (this.searchResourceType == 'person') {
-        this.search(this.statement.person_name);
-      } else if (this.searchResourceType == 'party') {
-        this.search(this.statement.parliamentary_group_name)
-      }
+      this.updateSearchResults()
+    },
+    updateSearchResults: function() {
+      this.search(this.searchTerm);
     },
     getLanguageCode: function () {
       return localStorage.getItem(wikidataClient.page + '.language') || this.languageCode;


### PR DESCRIPTION
This also lays out the reconcilable component a bit more like a
standard search page.

Partial fix for #313.

Pair-programmed with Zarino Zappia (@zarino)

![image](https://user-images.githubusercontent.com/7907/43135523-9d41764e-8f3d-11e8-9804-f2d95c55f91a.png)
