### PR TITLE
Rename person during reconcilation, rather than verification

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -118,6 +118,36 @@ $color_pale_grey: #eee;
     width: 0;
 }
 
+.verification-tool__search-results {
+    list-style: none;
+    margin: 0;
+
+    li {
+        padding-top: 1em;
+        margin-top: 1em;
+        border-top: 1px solid rgba(#000, 0.1);
+        display: flex;
+        align-items: center;
+
+        & > button {
+            flex: 0 0 auto;
+            margin-right: 1em;
+        }
+
+        & > div {
+            flex: 1 1 auto;
+        }
+    }
+
+    p.description {
+        margin: 0;
+    }
+
+    .searchmatch {
+        background-color: rgba(#ff0, 0.7);
+    }
+}
+
 .verification-tool__controls {
     @include clearfix();
     margin: 0 -0.5em -0.5em -0.5em;

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -7,9 +7,9 @@
   <span v-else>
     <h3>
       Results for
-      <input v-model="searchTerm" type="search">
+      <input v-model="searchTerm" type="search" v-on:keyup.enter="changeLanguage()">
       from Wikidata and
-      <input v-model="languageCode" class="language-chooser">.wikipedia.org
+      <input v-model="languageCode" class="language-chooser"v-on:keyup.enter="changeLanguage()">.wikipedia.org
       <button v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Update results</button>
     </h3>
     <ul class="verification-tool__search-results">

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -12,17 +12,22 @@
       <input v-model="languageCode" class="language-chooser">.wikipedia.org
       <button v-on:click="changeLanguage()" class="mw-ui-button mw-ui-progressive">Update results</button>
     </h3>
-    <ul class="wp-search-results">
+    <ul class="verification-tool__search-results">
       <li v-for="wdResult in searchResults.fromWikidata">
         <button v-on:click="reconcileWithItem(wdResult.item)" class="mw-ui-button">Use this</button>
-        <span class="item-from-search">{{ wdResult.item }}</span>
-        <a target="_blank" rel="noopener nofollow" class="external free" :href="wdResult.url">{{ wdResult.label }} ({{ wdResult.description }})</a>
+        <div>
+          <a target="_blank" rel="noopener nofollow" class="external free name" :href="wdResult.url">{{ wdResult.label }}</a>
+          <span class="item-from-search">{{ wdResult.item }}</span>
+          <p class="description">{{ wdResult.description }}</p>
+        </div>
       </li>
       <li v-for="wpResult in searchResults.fromWikipedia">
         <button v-on:click="reconcileWithItem(wpResult.item)" class="mw-ui-button">Use this</button>
-        <span class="item-from-search">{{ wpResult.item }}</span>
-        <a target="_blank" rel="noopener nofollow" class="external free" :href="wpResult.wpURL">{{ wpResult.title }} </a>
-        <div v-html="wpResult.snippetHTML"></div>
+        <div>
+          <a target="_blank" rel="noopener nofollow" class="external free name" :href="wpResult.wpURL">{{ wpResult.title }} </a>
+          <span class="item-from-search">{{ wpResult.item }}</span>
+          <p v-html="wpResult.snippetHTML" class="description"></p>
+        </div>
       </li>
       <li v-if="this.searchResourceType === 'person'">
         <button v-on:click="createPerson()" class="mw-ui-button">Create new item: {{ searchTerm }}</button>

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -60,7 +60,7 @@ export default template({
       wikidataClient.createPerson(
         {
           lang: this.country.label_lang,
-          value: this.statement.person_name,
+          value: this.searchTerm,
         },
         {
           lang: 'en',

--- a/app/javascript/components/verifiable.html
+++ b/app/javascript/components/verifiable.html
@@ -1,14 +1,6 @@
 <span>
   <p>Does <a target="_blank" rel="noopener nofollow" class="external free" :href="page.reference_url">{{ page.reference_url }}</a> provide evidence for this position?</p>
 
-  <span v-if="!changingName">
-    <button v-on:click="submitStatement(true)" class="mw-ui-button mw-ui-progressive">Yes, verify</button>
-    <button v-on:click="changeName()" class="mw-ui-button">Yes, but their name isn't quite right</button>
-    <button v-on:click="submitStatement(false)" class="mw-ui-button">No evidence</button>
-  </span>
-  <span v-else>
-    <label for="name">New name: <input v-model="newName" name="name"></label>
-    <button v-on:click="submitStatement(true)" class="mw-ui-button mw-ui-progressive">Verify with new name</button>
-    <button v-on:click="cancelChangeName()" class="mw-ui-button">Cancel</button>
-  </span>
+  <button v-on:click="submitStatement(true)" class="mw-ui-button mw-ui-progressive">Yes, verify</button>
+  <button v-on:click="submitStatement(false)" class="mw-ui-button">No evidence</button>
 </span>

--- a/app/javascript/components/verifiable.js
+++ b/app/javascript/components/verifiable.js
@@ -1,42 +1,20 @@
 import ENV from '../env'
 import Axios from 'axios'
-import Levenshtein from 'js-levenshtein'
 import wikidataClient from '../wikiapi'
 import template from './verifiable.html'
 
 export default template({
-  data () { return {
-    changingName: false,
-    newName: null
-  } },
+  data () { return {} },
   props: ['statement', 'page', 'country'],
   methods: {
     submitStatement: function (status) {
-      if (this.newName && Levenshtein(this.newName, this.statement.person_name) > 5) {
-        alert(
-          'The name is too different to the name in the original statement.' +
-          '\n\n' +
-          'Only minor spelling mistakes should be corrected.'
-        )
-        return false
-      }
-
       this.$parent.$emit('statement-update', () => {
         return Axios.post(ENV.url + '/verifications.json', {
           id: this.statement.transaction_id,
           user: wikidataClient.user,
-          new_name: this.newName,
           status
         })
       })
-    },
-    changeName: function () {
-      this.changingName = true
-      this.newName = this.newName || this.statement.person_name
-    },
-    cancelChangeName: function () {
-      this.changingName = false
-      this.newName = null
     }
   }
 })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-preset-vue": "^2.0.1",
-    "js-levenshtein": "^1.1.3",
     "jsonp": "^0.2.1",
     "parse-full-name": "^1.2.3",
     "sass-loader": "^6.0.7",


### PR DESCRIPTION
Fixes #313. Work done while pairing with @mhl.

# Verification stage:

<img width="1027" alt="screen shot 2018-07-24 at 15 13 11" src="https://user-images.githubusercontent.com/739624/43144124-4cc2ce18-8f54-11e8-9aba-9d90f9009bf9.png">

# Reconciliation stage (after having pressed “Search for person”)

<img width="1023" alt="screen shot 2018-07-24 at 15 14 00" src="https://user-images.githubusercontent.com/739624/43144132-5025c74a-8f54-11e8-904b-6343f128be80.png">

This completes the work in 71ac1a11d701c12c430d.