### PR TITLE
Move cell labels to top of table

### DIFF
--- a/app/javascript/app.css.scss
+++ b/app/javascript/app.css.scss
@@ -31,11 +31,27 @@ $color_pale_grey: #eee;
 
 .verification-tool__table {
     width: 100%;
-    border-collapse: collapse;
+    border-spacing: 0;
 
     td {
         padding: 1em;
         vertical-align: top;
+    }
+
+    th {
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+        background: transparent linear-gradient(to bottom, #fff 66%, transparent);
+
+        padding: 1em;
+        text-align: inherit;
+    }
+
+    thead {
+        & + tbody tr:first-child td {
+            padding-top: 0;
+        }
     }
 
     h3 {
@@ -102,12 +118,6 @@ $color_pale_grey: #eee;
   100% {
     background: #ffffff;
   }
-}
-
-.verification-tool__table__cell-label {
-    font-size: 0.8em;
-    font-weight: bold;
-    display: block;
 }
 
 .verification-tool__table__cell-link {

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -46,18 +46,23 @@
   </div>
   <div v-if="loaded && currentStatements.length > 0">
     <table class="verification-tool__table">
+      <thead>
+        <tr>
+          <th>Subject</th>
+          <th>District</th>
+          <th>Parliamentary group</th>
+          <th></th>
+        </tr>
+      </thead>
       <tbody v-for="statement in currentStatements">
       <tr :id="'s:' + statement.transaction_id">
         <td>
-          <span class="verification-tool__table__cell-label">Subject</span>
           <wikilink :id="statement.person_item">{{ statement.person_name }}</wikilink>
         </td>
         <td>
-          <span class="verification-tool__table__cell-label">District</span>
           <wikilink :id="statement.electoral_district_item">{{ statement.electoral_district_name || '&nbsp;' }}</wikilink>
         </td>
         <td>
-          <span class="verification-tool__table__cell-label">Parliamentary group</span>
           <wikilink :id="statement.parliamentary_group_item">{{ statement.parliamentary_group_name || '&nbsp;' }}</wikilink>
         </td>
         <td class="verification-tool__table__cell--narrow">


### PR DESCRIPTION
An effort to improve information density, as per #337.

In modern browsers, the table header will stick to the top of the
window as you scroll down the table. This required a slight change to
how we collapsed table borders (swapping `border-collapse: collapse`
for `border-spacing: 0`) because the `border-collapse` was resulting
in half-width (!!) borders when combined with `position: sticky`.