### PR TITLE
Disable setting reference URL title and language

### DIFF
--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -48,26 +48,29 @@ export default template({
         value: this.statement.verified_on, type: 'time'
       }
 
-      if (this.page.reference_url_title) {
-        references[wikidataClient.getPropertyID('title')] = {
-          value: {
-            text: this.page.reference_url_title,
-            // FIXME: This needs to be set dynamically depending on the
-            // language of the page, but we can't just use
-            // page.reference_url_language, because that's a Q value, not a
-            // plain string.
-            language: 'en',
-          },
-          type: 'monolingualtext'
-        };
-      }
+      // TODO: Make sure the FIXME below has been corrected before enabling
+      // this code again.
+      //
+      // if (this.page.reference_url_title) {
+      //   references[wikidataClient.getPropertyID('title')] = {
+      //     value: {
+      //       text: this.page.reference_url_title,
+      //       // FIXME: This needs to be set dynamically depending on the
+      //       // language of the page, but we can't just use
+      //       // page.reference_url_language, because that's a Q value, not a
+      //       // plain string.
+      //       language: 'en',
+      //     },
+      //     type: 'monolingualtext'
+      //   };
+      // }
 
-      if (this.page.reference_url_language) {
-        references[wikidataClient.getPropertyID('language of work or name')] = {
-          value: getItemValue(this.page.reference_url_language),
-          type: 'wikibase-entityid'
-        };
-      }
+      // if (this.page.reference_url_language) {
+      //   references[wikidataClient.getPropertyID('language of work or name')] = {
+      //     value: getItemValue(this.page.reference_url_language),
+      //     type: 'wikibase-entityid'
+      //   };
+      // }
 
       if (!this.page.executive_position && this.statement.parliamentary_group_item) {
         qualifiers[wikidataClient.getPropertyID('parliamentary group')] =

--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -50,8 +50,15 @@ export default template({
 
       if (this.page.reference_url_title) {
         references[wikidataClient.getPropertyID('title')] = {
-          value: this.page.reference_url_title,
-          type: 'string'
+          value: {
+            text: this.page.reference_url_title,
+            // FIXME: This needs to be set dynamically depending on the
+            // language of the page, but we can't just use
+            // page.reference_url_language, because that's a Q value, not a
+            // plain string.
+            language: 'en',
+          },
+          type: 'monolingualtext'
         };
       }
 

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -462,7 +462,7 @@ var wikidata = function(spec) {
         'electoral district': 'P70558',
         'position held': 'P39',
         'parliamentary term': 'P70901',
-        'title': 'P95',
+        'title': 'P77107',
         'language of work or name': 'P77090',
       },
       'localhost': {
@@ -478,7 +478,7 @@ var wikidata = function(spec) {
         'electoral district': 'P70558',
         'position held': 'P39',
         'parliamentary term': 'P70901',
-        'title': 'P95',
+        'title': 'P77107',
         'language of work or name': 'P77090',
       }
     }

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -43,6 +43,7 @@
     </div>
     <%= f.error_span(:reference_url) %>
   </div>
+  <!--
   <div class="form-group">
     <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
@@ -57,6 +58,7 @@
     </div>
     <%= f.error_span(:reference_url_language) %>
   </div>
+  -->
   <div class="form-group">
     <%= f.label :csv_source_url, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -16,10 +16,12 @@
   <dd><%= @page.parliamentary_term_item %></dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= @page.reference_url %></dd>
+  <!--
   <dt><strong><%= model_class.human_attribute_name(:reference_url_title) %>:</strong></dt>
   <dd><%= @page.reference_url_title %></dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url_language) %>:</strong></dt>
   <dd><%= @page.reference_url_language %></dd>
+  -->
   <dt><strong><%= model_class.human_attribute_name(:csv_source_url) %>:</strong></dt>
   <dd><%= @page.csv_source_url %></dd>
   <dt><strong><%= model_class.human_attribute_name(:country_id) %>:</strong></dt>


### PR DESCRIPTION
This pull request disables the reference URL title and language that were added in #342. This is because it's not working correctly at the moment because of #364, but in order to fix it we need to supply a language code string for the title, but we only have the language as a `Q` value, and it's going to require more time than we have right now to resolve that.

Part of #364 