### PR TITLE
Fix scrolling to a fragment now there's a sticky table header

### DIFF
--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -43,15 +43,18 @@ export default template({
     this.$on('statements-loaded', () => {
       this.$nextTick(function () {
         var hash = window.location.hash;
-        var statementRow;
         if (hash) {
-          statementRow = document.querySelector(hash.replace(/:/g, '\\:'))
-          if (statementRow) {
-            statementRow.scrollIntoView()
-            statementRow.className += " targetted"
-          }
+          this.$emit('scroll-to-fragment', hash)
         }
       })
+    }),
+    this.$on('scroll-to-fragment', (fragment) => {
+      let selector = fragment.replace(/:/g, '\\:')
+      let statementRow = document.querySelector(selector)
+      if (statementRow) {
+        statementRow.scrollIntoView()
+        statementRow.className += " targetted"
+      }
     })
   },
   methods: {

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -52,7 +52,9 @@ export default template({
       let selector = fragment.replace(/:/g, '\\:')
       let statementRow = document.querySelector(selector)
       if (statementRow) {
+        let headerHeight = document.querySelector('.verification-tool__table th').offsetHeight
         statementRow.scrollIntoView()
+        window.scrollBy(0, -headerHeight)
         statementRow.className += " targetted"
       }
     })

--- a/app/javascript/components/statement.html
+++ b/app/javascript/components/statement.html
@@ -45,7 +45,7 @@
     </div>
   </td>
   <td class="verification-tool__table__cell--narrow">
-    <a class="verification-tool__table__cell-link" :href="'#s:' + statement.transaction_id" title="Link to this statement">§</a>
+    <a class="verification-tool__table__cell-link" :href="'#s:' + statement.transaction_id" v-on:click="scrollHere($event)" title="Link to this statement">§</a>
   </td>
 </tr>
 <tr>

--- a/app/javascript/components/statement.js
+++ b/app/javascript/components/statement.js
@@ -73,6 +73,12 @@ export default template({
     },
     changeVerification: function(field) {
       this.statement.type = 'verifiable'
+    },
+    scrollHere: function(event) {
+      let fragment = event.currentTarget.hash
+      window.location = fragment
+      this.$parent.$emit('scroll-to-fragment', fragment)
+      event.preventDefault()
     }
   }
 })


### PR DESCRIPTION
Now that there's a sticky header we need to scroll to a different point on the page when someone's navigating to a fragment.

Fixes #370 

![screenshot-fragment](https://user-images.githubusercontent.com/7907/43279396-be716bde-9105-11e8-9f9d-6f9375aab080.png)
