### PR TITLE
Add option to sort by first name

### DIFF
--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -31,6 +31,7 @@
       <label for="sortBy">Sort by</label>
       <select v-model="sortBy" id="sortBy">
         <option value="lastName">Last name</option>
+        <option value="firstName">First name</option>
         <option value="parliamentaryGroup">Parliamentary group</option>
         <option value="district">District</option>
       </select>

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -82,18 +82,25 @@ export default template({
       }
     },
     sortStatements: function (statements) {
-      var prefix
-
-      switch (this.sortBy) {
-        case 'parliamentaryGroup': prefix = 'parliamentary_group_name'; break
-        case 'district': prefix = 'electoral_district_name'; break
-      }
-
-      return statements.sort(function (a, b) {
+      return statements.sort((a, b) => {
         const namesA = parseFullName(a.person_name)
         const namesB = parseFullName(b.person_name)
-        const stringA = (a[prefix] + ' ' || '') + namesA.last + ' ' + namesA.first + ' ' + a.transaction_id
-        const stringB = (b[prefix] + ' ' || '') + namesB.last + ' ' + namesB.first + ' ' + b.transaction_id
+        const statementA = Object.assign({}, a, { firstName: namesA.first, lastName: namesA.last })
+        const statementB = Object.assign({}, b, { firstName: namesB.first, lastName: namesB.last })
+        let sortFields
+        switch (this.sortBy) {
+          case 'lastName':
+            sortFields = ['lastName', 'firstName']
+            break
+          case 'parliamentaryGroup':
+            sortFields = ['parliamentary_group_name', 'lastName', 'firstName']
+            break
+          case 'district':
+            sortFields = ['electoral_district_name', 'lastName', 'firstName']
+            break
+        }
+        const stringA = sortFields.map(field => statementA[field]).join(' ')
+        const stringB = sortFields.map(field => statementB[field]).join(' ')
         return stringA.localeCompare(stringB)
       })
     }

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -92,6 +92,9 @@ export default template({
           case 'lastName':
             sortFields = ['lastName', 'firstName']
             break
+          case 'firstName':
+            sortFields = ['firstName', 'lastName']
+            break
           case 'parliamentaryGroup':
             sortFields = ['parliamentary_group_name', 'lastName', 'firstName']
             break


### PR DESCRIPTION
This adds an additional option to the "Sort by" dropdown to allow sorting by first name.

Fixes https://github.com/mysociety/verification-pages/issues/287

## Notes to reviewer

I've removed the `transaction_id` from the fields we were using for sorting as it didn't seem relevant, but I'm happy to add it back in if there's a reason we need it that I've missed!

## Screenshot

![image](https://user-images.githubusercontent.com/22996/43318936-be68c034-919a-11e8-9c07-67d96df54df5.png)
