### PR TITLE
Replace filtering with sorting by statement type

### DIFF
--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -1,20 +1,15 @@
 <div id="verification-tool">
   <div v-if="loaded" class="verification-tool__controls">
-    <div class="verification-tool__controls__group">
-      <label for="sortBy">Sort by</label>
-      <select v-model="sortBy" id="sortBy">
-        <option value="lastName">Last name</option>
-        <option value="firstName">First name</option>
-        <option value="parliamentaryGroup">Parliamentary group</option>
-        <option value="district">District</option>
-        <option value="type">Type</option>
-      </select>
-    </div>
+    <sort-control
+      v-bind:options="sortOptions"
+      v-bind:selectedOption="sortBy"
+      v-on:sort="sortStatements"
+    ></sort-control>
   </div>
-  <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
+  <div v-if="loaded && statements.length === 0" class="verification-tool__blank-slate">
     No statements
   </div>
-  <div v-if="loaded && currentStatements.length > 0">
+  <div v-if="loaded && statements.length > 0">
     <table class="verification-tool__table">
       <thead>
         <tr>
@@ -25,7 +20,7 @@
           <th></th>
         </tr>
       </thead>
-      <Statement v-for="statement in currentStatements" :statement="statement" :page="page" :country="country"></Statement>
+      <Statement v-for="statement in statements" :statement="statement" :page="page" :country="country"></Statement>
     </table>
   </div>
   <div v-if="!loaded" class="verification-tool__blank-slate">

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -34,6 +34,7 @@
         <option value="firstName">First name</option>
         <option value="parliamentaryGroup">Parliamentary group</option>
         <option value="district">District</option>
+        <option value="type">Type</option>
       </select>
     </div>
   </div>

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -1,33 +1,6 @@
 <div id="verification-tool">
   <div v-if="loaded" class="verification-tool__controls">
     <div class="verification-tool__controls__group">
-      <label for="displayType">Type</label>
-      <select v-model="displayType" id="displayType">
-        <option value="all">Show all ({{ countStatementsOfType('all') }})</option>
-        <option value="verifiable" v-bind:disabled="countStatementsOfType('verifiable') === 0">
-          Verifiable ({{ countStatementsOfType('verifiable') }})
-        </option>
-        <option value="unverifiable" v-bind:disabled="countStatementsOfType('unverifiable') === 0">
-          Unverifiable ({{ countStatementsOfType('unverifiable') }})
-        </option>
-        <option value="reconcilable" v-bind:disabled="countStatementsOfType('reconcilable') === 0">
-          Reconcilable ({{ countStatementsOfType('reconcilable') }})
-        </option>
-        <option value="actionable" v-bind:disabled="countStatementsOfType('actionable') === 0">
-          Actionable ({{ countStatementsOfType('actionable') }})
-        </option>
-        <option value="manually_actionable" v-bind:disabled="countStatementsOfType('manually_actionable') === 0">
-          Manually actionable ({{ countStatementsOfType('manually_actionable') }})
-        </option>
-        <option value="done" v-bind:disabled="countStatementsOfType('done') === 0">
-          Done ({{ countStatementsOfType('done') }})
-        </option>
-        <option value="reverted" v-bind:disabled="countStatementsOfType('reverted') === 0">
-          Reverted ({{ countStatementsOfType('reverted') }})
-        </option>
-      </select>
-    </div>
-    <div class="verification-tool__controls__group">
       <label for="sortBy">Sort by</label>
       <select v-model="sortBy" id="sortBy">
         <option value="lastName">Last name</option>
@@ -39,12 +12,7 @@
     </div>
   </div>
   <div v-if="loaded && currentStatements.length === 0" class="verification-tool__blank-slate">
-    <div v-if="displayType === 'all'">
-      No statements
-    </div>
-    <div v-else>
-      No “{{ displayType }}” statements – <a v-on:click="displayType = 'all'">Try showing all statements</a>
-    </div>
+    No statements
   </div>
   <div v-if="loaded && currentStatements.length > 0">
     <table class="verification-tool__table">

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -6,8 +6,10 @@ import template from './app.html?style=./app.css'
 import { parseFullName } from 'parse-full-name'
 
 import statementComponent from './components/statement'
+import SortControl from './components/sort_control'
 
 Vue.component('Statement', statementComponent)
+Vue.component('sort-control', SortControl)
 
 export default template({
   data () {
@@ -15,12 +17,14 @@ export default template({
       loaded: false,
       statements: [],
       sortBy: 'lastName',
+      sortOptions: [
+        ['lastName', 'Last name'],
+        ['firstName', 'First name'],
+        ['district', 'District'],
+        ['parliamentaryGroup', 'Parliamentary group'],
+        ['type', 'Type']
+      ],
       page: null
-    }
-  },
-  computed: {
-    currentStatements: function () {
-      return this.sortStatements(this.statements)
     }
   },
   created: function () {
@@ -64,6 +68,7 @@ export default template({
         params: { title: wikidataClient.page }
       }).then(response => {
         this.statements = response.data.statements
+        this.sortStatements(this.sortBy)
         this.page = response.data.page
         this.country = response.data.country
       }).then(() => {
@@ -78,8 +83,8 @@ export default template({
         return this.statements.length
       }
     },
-    sortStatements: function (statements) {
-      return statements.sort((a, b) => {
+    sortStatements: function (sortBy) {
+      this.statements = this.statements.sort((a, b) => {
         const typeOrder = [
           'verifiable',
           'reconcilable',
@@ -102,7 +107,7 @@ export default template({
           typeSort: typeOrder.indexOf(b.type)
         })
         let sortFields
-        switch (this.sortBy) {
+        switch (sortBy) {
           case 'lastName':
             sortFields = ['lastName', 'firstName']
             break

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -14,14 +14,13 @@ export default template({
     return {
       loaded: false,
       statements: [],
-      displayType: 'all',
       sortBy: 'lastName',
       page: null
     }
   },
   computed: {
     currentStatements: function () {
-      return this.sortStatements(this.filterStatements(this.statements))
+      return this.sortStatements(this.statements)
     }
   },
   created: function () {
@@ -77,13 +76,6 @@ export default template({
         return this.statements.filter(s => s.type === type).length
       } else {
         return this.statements.length
-      }
-    },
-    filterStatements: function (statements) {
-      if (this.displayType !== 'all') {
-        return statements.filter(s => s.type === this.displayType)
-      } else {
-        return statements
       }
     },
     sortStatements: function (statements) {

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -88,10 +88,27 @@ export default template({
     },
     sortStatements: function (statements) {
       return statements.sort((a, b) => {
+        const typeOrder = [
+          'verifiable',
+          'reconcilable',
+          'actionable',
+          'manually_actionable',
+          'reverted',
+          'unverifiable',
+          'done',
+        ]
         const namesA = parseFullName(a.person_name)
         const namesB = parseFullName(b.person_name)
-        const statementA = Object.assign({}, a, { firstName: namesA.first, lastName: namesA.last })
-        const statementB = Object.assign({}, b, { firstName: namesB.first, lastName: namesB.last })
+        const statementA = Object.assign({}, a, {
+          firstName: namesA.first,
+          lastName: namesA.last,
+          typeSort: typeOrder.indexOf(a.type)
+        })
+        const statementB = Object.assign({}, b, {
+          firstName: namesB.first,
+          lastName: namesB.last,
+          typeSort: typeOrder.indexOf(b.type)
+        })
         let sortFields
         switch (this.sortBy) {
           case 'lastName':
@@ -105,6 +122,9 @@ export default template({
             break
           case 'district':
             sortFields = ['electoral_district_name', 'lastName', 'firstName']
+            break
+          case 'type':
+            sortFields = ['typeSort', 'lastName', 'firstName']
             break
         }
         const stringA = sortFields.map(field => statementA[field]).join(' ')

--- a/app/javascript/components/sort_control.html
+++ b/app/javascript/components/sort_control.html
@@ -1,0 +1,7 @@
+<div class="verification-tool__controls__group">
+  <label for="sortBy">Sort by</label>
+  <select v-model="sortBy" id="sortBy">
+    <option v-for="(label, value) of options" v-bind:value="value">{{ label }}</option>
+  </select>
+  <button v-on:click="$emit('sort', sortBy)">Sort</button>
+</div>

--- a/app/javascript/components/sort_control.html
+++ b/app/javascript/components/sort_control.html
@@ -1,7 +1,7 @@
 <div class="verification-tool__controls__group">
   <label for="sortBy">Sort by</label>
   <select v-model="sortBy" id="sortBy">
-    <option v-for="(label, value) of options" v-bind:value="value">{{ label }}</option>
+    <option v-for="[value, label] of options" v-bind:value="value">{{ label }}</option>
   </select>
   <button v-on:click="$emit('sort', sortBy)">Sort</button>
 </div>

--- a/app/javascript/components/sort_control.js
+++ b/app/javascript/components/sort_control.js
@@ -1,0 +1,10 @@
+import template from './sort_control.html'
+
+export default template({
+  data () {
+    return {
+      sortBy: this.selectedOption
+    }
+  },
+  props: ['options', 'selectedOption']
+})


### PR DESCRIPTION
This adds a "Type" option to the "Sort by" dropdown to allow you to sort statements by type. It also adds a "Sort" button, and the statements will only be re-sorted when that button is pressed.

Fixes #79
Fixes #372
Fixes #373
