### PR TITLE
Have a single, simple button for the 'actionable' state

### DIFF
--- a/app/javascript/components/actionable.html
+++ b/app/javascript/components/actionable.html
@@ -1,15 +1,7 @@
 <div>
   <div v-if="!finished && !updateError">
     <p>
-      You can update Wikidata with the following 'position held' information for statement for
-      <wikilink :id="statement.person_item">{{ statement.person_name }}</wikilink>
-      now:
-    </p>
-
-    <StatementChangeSummary :statement="statement" :page="page"></StatementChangeSummary>
-
-    <p>
-      <button v-on:click="updatePositionHeld()" class="mw-ui-button mw-ui-progressive">Create or update 'position held'</button>
+      <button v-on:click="updatePositionHeld()" class="mw-ui-button mw-ui-progressive">Submit to Wikidata</button>
     </p>
   </div>
   <div v-else-if="finished && updateError">


### PR DESCRIPTION
This text didn't appear much any more, but it still provides a lot of
information that is only helpful to a very small minority of users, and
makes it look confusing and intimidating to the rest. It wasn't even very
helpful for developers, since it just showed how the qualifiers it would
like a P39 to have, and nothing about what was there already.

Fixes the first part of #384 

![new-actionable-prompt](https://user-images.githubusercontent.com/7907/43457111-bff1d866-94bd-11e8-9463-4c4a1832a59c.png)
