### PR TITLE
Show country name on statistics page

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -12,6 +12,7 @@ class StatementsController < FrontendController
 
   def statistics
     @country_statements = StatementsStatistics.new.statistics
+    @country_lookup = Country.all.map { |c| [c.code, c] }.to_h
   end
 
   def show

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -1,5 +1,12 @@
 <% @country_statements.each do |country_code, statements| %>
-  <h2><%= country_code %></h2>
+  <h2>
+    <% if country = @country_lookup[country_code.downcase] %>
+      <%= link_to country.name, country %>
+    <% else %>
+      <%= country_code %>
+      <%= link_to '(create country)', new_country_path %>
+    <% end %>
+  </h2>
   <table class="wikitable">
     <thead>
       <tr>

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -28,7 +28,7 @@
             title: "User:Verification_pages_bot/verification/#{country_code.downcase}/",
             position_held_item: statement.position,
             csv_source_url: "#{ENV['SUGGESTIONS_STORE_URL']}export/#{country_code.downcase}/#{statement.position}.csv",
-            country_id: Country.find_by(code: country_code.downcase)
+            country_id: @country_lookup[country_code.downcase]
           ) %>)
         <% end %></td>
         <td><%= statement.unchecked %></td>


### PR DESCRIPTION
If a country already exists in the database then show the full country name. Otherwise show the country code and a link to create that country.

Fixes #274 

![image](https://user-images.githubusercontent.com/22996/43529237-c5c22d46-95a2-11e8-9ae9-3ed3f7c82207.png)
