### PR TITLE
Show position labels on the statistics page

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -13,6 +13,8 @@ class StatementsController < FrontendController
   def statistics
     @country_statements = StatementsStatistics.new.statistics
     @country_lookup = Country.all.map { |c| [c.code, c] }.to_h
+    positions = @country_statements.values.flatten.map(&:position)
+    @position_name_mapping = PositionNameMapping.new(positions: positions).mapping
   end
 
   def show

--- a/app/lib/position_name_mapping.rb
+++ b/app/lib/position_name_mapping.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PositionNameMapping
+  def initialize(positions:)
+    @positions = positions.compact
+  end
+
+  def mapping
+    wikidata_api_lookup(positions).map do |data|
+      [data['id'], data.dig('labels', 'en', 'value') || 'no label']
+    end.to_h
+  end
+
+  private
+
+  attr_reader :positions
+
+  def wikidata_api_lookup(items)
+    items.each_slice(50).flat_map do |items_slice|
+      url = wikidata_api_url + items_slice.join('|')
+      JSON.parse(RestClient.get(url))['entities'].values
+    end
+  end
+
+  def wikidata_api_url
+    'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&ids='
+  end
+end

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -20,7 +20,12 @@
     <tbody>
       <% statements.each do |statement| %>
       <tr>
-        <td><%= link_to statement.position, "https://www.wikidata.org/wiki/#{statement.position}" %></td>
+        <td>
+          <%= link_to "https://www.wikidata.org/wiki/#{statement.position}" do %>
+            <%= @position_name_mapping[statement.position] %>
+            <small>(<%= statement.position %>)</small>
+          <% end %>
+        </td>
         <td><% if statement.pages.each do |page_title| %>
           <a href="https://www.wikidata.org/wiki/<%= page_title %>"><%= page_title %></a>
           <% end.empty? %>


### PR DESCRIPTION
This adds a PositionNameMapping class which looks up a list of items on
Wikidata and returns a mapping between the Qid and the label in English.
This is then used on the statistics page to show the full name of a
position, rather than just the ID.

Fixes #275 

## Notes to merger

Please complete the following **before** merging:

- [x] Change the base branch of this pull request to `master` once #394 has been merged

## Screenshot

![image](https://user-images.githubusercontent.com/22996/43530217-ee425154-95a4-11e8-9918-b1a37a472220.png)
