### PR TITLE
Increase length of pages.reference_url column

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -7,6 +7,6 @@ class Page < ApplicationRecord
 
   validates :title, presence: true, uniqueness: true
   validates :position_held_item, presence: true
-  validates :reference_url, presence: true
+  validates :reference_url, presence: true, length: { maximum: 2000 }
   validates :csv_source_url, presence: true
 end

--- a/db/migrate/20180809155552_change_page_reference_url_length.rb
+++ b/db/migrate/20180809155552_change_page_reference_url_length.rb
@@ -1,0 +1,5 @@
+class ChangePageReferenceUrlLength < ActiveRecord::Migration[5.2]
+  def change
+    change_column :pages, :reference_url, :string, limit: 2000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_28_130458) do
+ActiveRecord::Schema.define(version: 2018_08_09_155552) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 2018_07_28_130458) do
     t.string "title", null: false
     t.string "position_held_item", null: false
     t.string "parliamentary_term_item"
-    t.string "reference_url", null: false
+    t.string "reference_url", limit: 2000, null: false
     t.boolean "require_parliamentary_group", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
We've run into problems where the reference URL is longer than we can fit into the `reference_url` column currently, so to avoid those problems increase the column's length to 2000, which is consistent with the length of `pages.csv_source_url`.

Fixes #361
Fixes #362 