### PR TITLE
Override reference url for individual statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,17 @@ If `foreman start` just exits with:
     18:16:08 webpacker.1 | terminated by SIGTERM
 
 ... try running `rails server` to see the error message.
+
+## Architecture notes
+
+### Reference URL
+
+We currently store the reference URL, that is the URL that the verifier has
+said a statement is described at, in two different tables, which serve different purposes.
+
+1. The `reference_url` column in the `pages` table. If set, this is used as
+the default reference URL for the page.
+2. The `reference_url` column in the `verifications` table. Each time a
+statement is verified a row is added to this table with the `reference_url`
+that was used to verify it. This provides a historical log of URLs that have
+been used for verification.

--- a/app/javascript/app.html
+++ b/app/javascript/app.html
@@ -20,7 +20,13 @@
           <th></th>
         </tr>
       </thead>
-      <Statement v-for="statement in statements" :statement="statement" :page="page" :country="country"></Statement>
+      <Statement
+        v-for="statement in statements"
+        :statement="statement"
+        :page="page"
+        :country="country"
+        @reference-url-change="onChangeReferenceURL"
+      ></Statement>
     </table>
   </div>
   <div v-if="!loaded" class="verification-tool__blank-slate">

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -47,6 +47,10 @@ export default template({
         if (hash) {
           this.$emit('scroll-to-fragment', hash)
         }
+        const localStorageReferenceURL = localStorage.getItem(this.localStorageKey)
+        if (localStorageReferenceURL) {
+          this.page.reference_url = localStorageReferenceURL
+        }
       })
     })
     this.$on('find-matching-statements', (data, cb) => {
@@ -147,6 +151,12 @@ export default template({
     },
     onChangeReferenceURL: function (newReferenceURL) {
       this.page.reference_url = newReferenceURL
+      localStorage.setItem(this.localStorageKey, newReferenceURL)
+    }
+  },
+  computed: {
+    localStorageKey: function() {
+      return wikidataClient.page + '.reference_url'
     }
   }
 })

--- a/app/javascript/app.js
+++ b/app/javascript/app.js
@@ -144,6 +144,9 @@ export default template({
         const stringB = sortFields.map(field => statementB[field]).join(' ')
         return stringA.localeCompare(stringB)
       })
+    },
+    onChangeReferenceURL: function (newReferenceURL) {
+      this.page.reference_url = newReferenceURL
     }
   }
 })

--- a/app/javascript/components/statement.html
+++ b/app/javascript/components/statement.html
@@ -56,7 +56,7 @@
         :statement="statement"
         :page="page"
         :country="country"
-        @reference-url-change="onChangeReferenceURL"
+        @reference-url-change="$emit('reference-url-change', $event)"
       ></component>
     </keep-alive>
   </td>

--- a/app/javascript/components/statement.js
+++ b/app/javascript/components/statement.js
@@ -79,9 +79,6 @@ export default template({
       window.location = fragment
       this.$parent.$emit('scroll-to-fragment', fragment)
       event.preventDefault()
-    },
-    onChangeReferenceURL: function(url) {
-      this.page.reference_url = url
     }
   }
 })

--- a/app/javascript/components/verifiable.html
+++ b/app/javascript/components/verifiable.html
@@ -1,6 +1,22 @@
 <div>
-  <span v-if="page.reference_url">
-    <p>Is this shown at <a target="_blank" rel="noopener nofollow" class="external free" :href="page.reference_url">{{ page.reference_url }}</a>?</p>
+  <span v-if="askAboutOtherStatements">
+    <div>
+      <input type="radio" id="this-statement" v-model="referenceURLScope" value="this-statement">
+      <label for="this-statement">Change for this statement only</label>
+    </div>
+    <div>
+      <input type="radio" id="all-other-statements" v-model="referenceURLScope" value="all-statements">
+      <label for="all-other-statements">Change for all remaining statements</label>
+    </div>
+    <div>
+      <button v-on:click="onChangeReferenceURL">Continue</button>
+    </div>
+  </span>
+  <span v-else-if="!editing && page.reference_url">
+    <p>
+      Is this shown at <a target="_blank" rel="noopener nofollow" class="external free" :href="referenceURL">{{ referenceURL }}</a>?
+      <small>(<a v-on:click="editing = true">change reference URL</a>)</small>
+    </p>
 
     <button v-on:click="submitStatement(true)" class="mw-ui-button mw-ui-progressive">Yes</button>
     <button v-on:click="submitStatement(false)" class="mw-ui-button">No</button>
@@ -8,8 +24,9 @@
   <span v-else>
     <p>
       Please enter a reference URL:
-      <input v-model="referenceURL" type="url">
-      <button v-on:click="$emit('reference-url-change', referenceURL)">Save</button>
+      <input v-model="userReferenceURL" type="url" v-on:keypress.enter="askAboutOtherStatements = true">
+      <button v-on:click="askAboutOtherStatements = true">Save</button>
+      <a v-if="page.reference_url" v-on:click="editing = false">Cancel</a>
     </p>
   </span>
 </div>

--- a/app/javascript/components/verifiable.js
+++ b/app/javascript/components/verifiable.js
@@ -6,7 +6,11 @@ import template from './verifiable.html'
 export default template({
   data () {
     return {
-      referenceURL: ''
+      editing: false,
+      askAboutOtherStatements: false,
+      userReferenceURL: '',
+      overrideReferenceURL: '',
+      referenceURLScope: 'this-statement'
     }
   },
   props: ['statement', 'page', 'country'],
@@ -20,9 +24,23 @@ export default template({
           id: this.statement.transaction_id,
           user: wikidataClient.user,
           status,
-          reference_url: this.page.reference_url
+          reference_url: this.referenceURL
         })
       })
+    },
+    onChangeReferenceURL: function() {
+      if (this.referenceURLScope === 'all-statements') {
+        this.$emit('reference-url-change', this.userReferenceURL)
+      } else if (this.referenceURLScope === 'this-statement') {
+        this.overrideReferenceURL = this.userReferenceURL
+      }
+      this.editing = false
+      this.askAboutOtherStatements = false
+    }
+  },
+  computed: {
+    referenceURL: function() {
+      return this.overrideReferenceURL || this.page.reference_url
     }
   }
 })

--- a/app/models/verification.rb
+++ b/app/models/verification.rb
@@ -4,6 +4,8 @@
 class Verification < ApplicationRecord
   belongs_to :statement
 
+  validates :reference_url, presence: true
+
   default_scope -> { order(updated_at: :asc) }
 
   after_commit :send_to_suggestions_store

--- a/app/services/create_verification.rb
+++ b/app/services/create_verification.rb
@@ -4,14 +4,14 @@
 class CreateVerification < ServiceBase
   def initialize(statement:, params:)
     @statement = statement
-    @reference_url = params.delete(:reference_url)
     @params = params
   end
 
   def run
     statement.verifications.create!(params)
 
-    statement.page.update(reference_url: reference_url) if reference_url.present?
+    # Only update the reference URL on a page if it's missing
+    statement.page.update(reference_url: params[:reference_url]) if statement.page.reference_url.blank?
 
     # Find duplicate statements and update their verifications
     statement.duplicate_statements.each do |duplicate_statement|

--- a/db/migrate/20180817110527_add_reference_url_to_verifications.rb
+++ b/db/migrate/20180817110527_add_reference_url_to_verifications.rb
@@ -1,0 +1,5 @@
+class AddReferenceUrlToVerifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :verifications, :reference_url, :string, limit: 2000
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_13_095806) do
+ActiveRecord::Schema.define(version: 2018_08_17_110527) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2018_08_13_095806) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "new_name"
+    t.string "reference_url", limit: 2000
     t.index ["statement_id"], name: "index_verifications_on_statement_id"
   end
 

--- a/spec/models/verification_spec.rb
+++ b/spec/models/verification_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Verification, type: :model do
         )
         verification.statement = build(:statement, page: page)
         verification.user = 'Bilbo'
+        verification.reference_url = 'https://example.org/members/'
         verification.save! # create
 
         expect(UpdateStatementVerification).to receive(:run)
@@ -39,6 +40,7 @@ RSpec.describe Verification, type: :model do
 
         verification.statement = build(:statement)
         verification.user = 'Bilbo'
+        verification.reference_url = 'https://example.org/members/'
         verification.save! # create
 
         expect(UpdateStatementVerification).to_not receive(:run)
@@ -46,6 +48,15 @@ RSpec.describe Verification, type: :model do
         verification.user = 'Frodo'
         verification.save! # update
       end
+    end
+  end
+
+  describe 'validations' do
+    let(:verification) { Verification.new }
+
+    it 'requires reference_url' do
+      verification.valid?
+      expect(verification.errors).to include(:reference_url)
     end
   end
 end

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 
 RSpec.describe CreateVerification, type: :service do
   include_context 'id-mapping-store default setup'
+  let(:page) { create(:page) }
   let(:statement_params) do
     {
       person_name:             'Alice',
       electoral_district_name: 'Foo',
       electoral_district_item: 'Q123',
       fb_identifier:           '444333',
+      page:                    page,
     }
   end
   let(:statement) { create(:statement, statement_params) }
@@ -47,6 +49,21 @@ RSpec.describe CreateVerification, type: :service do
         statement_params.merge(transaction_id: '456')
       )
       expect { subject.run }.to change { statement2.verifications.count }.by(1)
+    end
+
+    context 'page.reference_url' do
+      let(:page) { create(:page, reference_url: '') }
+
+      it 'is set if blank' do
+        subject.run
+        expect(page.reference_url).to eq('https://example.org/members/')
+      end
+
+      it 'is left untouched if not blank' do
+        page.update(reference_url: 'http://example.com')
+        subject.run
+        expect(page.reference_url).to eq('http://example.com')
+      end
     end
   end
 end

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe CreateVerification, type: :service do
         statement: statement,
         params:    {
           user: 'foo', status: 'true', new_name: 'baz',
+          reference_url: 'https://example.org/members/',
         }
       )
     end


### PR DESCRIPTION
This adds a `reference_url` column to the `verifications` and `statements` table, so that we can keep track of the URLs that were used to verify a statement over time, and also have the latest URL available on the statement.

It also updates the JavaScript UI so that you can specify a per-statement reference URL.

Fixes #46