### PR TITLE
[#410] Duplicate statements must belong to the same page

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -49,6 +49,7 @@ class Statement < ApplicationRecord
 
   def duplicate_statements
     Statement.where(
+      page:                    page,
       person_name:             person_name,
       electoral_district_name: electoral_district_name,
       electoral_district_item: electoral_district_item,

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -5,4 +5,9 @@ FactoryBot.define do
     page
     transaction_id '123'
   end
+
+  factory :statement_with_names, class: Statement do
+    person_name { 'Person' }
+    electoral_district_name { 'District' }
+  end
 end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -107,4 +107,33 @@ RSpec.describe Statement, type: :model do
       )
     end
   end
+
+  describe '#duplicate_statements' do
+    let(:page) { build(:page) }
+    let(:page_2) { build(:page) }
+
+    let(:attributes) { attributes_for(:statement_with_names) }
+
+    let!(:statement) do
+      create(:statement, attributes.merge(transaction_id: '123', page: page))
+    end
+
+    let!(:duplicate) do
+      create(:statement, attributes.merge(transaction_id: '456', page: page))
+    end
+
+    let!(:other) do
+      create(:statement, attributes.merge(transaction_id: '789', page: page_2))
+    end
+
+    subject { statement.duplicate_statements }
+
+    it 'returns statements' do
+      is_expected.to include(duplicate)
+    end
+
+    it 'does not returns statements from other pages' do
+      is_expected.to_not include(other)
+    end
+  end
 end

--- a/spec/services/create_verification_spec.rb
+++ b/spec/services/create_verification_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CreateVerification, type: :service do
     it 'adds verification to duplicate statements' do
       statement2 = create(
         :statement,
-        statement_params.merge(transaction_id: '456')
+        statement_params.merge(transaction_id: '456', page: statement.page)
       )
       expect { subject.run }.to change { statement2.verifications.count }.by(1)
     end


### PR DESCRIPTION
Otherwise we can't have the same person standing in the same position for
a different term.

Fixes: https://github.com/mysociety/verification-pages/issues/410