### PR TITLE
Allow pages to viewed as JSON at /pages.json

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,4 +9,8 @@ class Page < ApplicationRecord
   validates :position_held_item, presence: true
   validates :reference_url, length: { maximum: 2000 }
   validates :csv_source_url, presence: true
+
+  def from_suggestions_store?
+    /^#{Regexp.escape(ENV.fetch('SUGGESTIONS_STORE_URL'))}/.match?(csv_source_url)
+  end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -57,9 +57,7 @@ class Statement < ApplicationRecord
     ).where.not(id: id).order(created_at: :asc)
   end
 
-  def from_suggestions_store?
-    /^#{Regexp.escape(ENV.fetch('SUGGESTIONS_STORE_URL'))}/.match?(page.csv_source_url)
-  end
+  delegate :from_suggestions_store?, to: :page
 
   private
 

--- a/app/views/pages/index.json.jbuilder
+++ b/app/views/pages/index.json.jbuilder
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+json.pages(
+  @pages,
+  :id, :title, :position_held_item, :parliamentary_term_item,
+  :reference_url,
+  :executive_position,
+  :csv_source_url,
+  :country_id,
+  :reference_url_title,
+  :reference_url_language,
+  :created_at, :updated_at,
+  :from_suggestions_store?,
+  :require_parliamentary_group,
+  :country
+)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe Page, type: :model do
       expect(page.errors).to include(:csv_source_url)
     end
   end
+
+  describe '#from_suggestions_store?' do
+    it 'knows that it came from suggestions-store' do
+      page = create(:page, csv_source_url: "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/blah.csv")
+      expect(page.from_suggestions_store?).to eq(true)
+    end
+
+    it 'know that it didn\'t come from suggestions-store' do
+      page = create(:page)
+      expect(page.from_suggestions_store?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
We will need this from the politician-data build process in order to find
all the suggestions-store-backed verification pages set up for a
particular country.
