### PR TITLE
Show invalid statements on statistic view

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -13,7 +13,7 @@ class StatementsController < FrontendController
   def statistics
     @country_statements = StatementsStatistics.new.statistics
     @country_lookup = Country.all.map { |c| [c.code, c] }.to_h
-    positions = @country_statements.values.flatten.map(&:position)
+    positions = @country_statements.values.map(&:first).flatten.map(&:position)
     @position_name_mapping = PositionNameMapping.new(positions: positions).mapping
   end
 

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -8,7 +8,8 @@ class StatementsStatistics
   def statistics
     countries.map do |country|
       statements = JSON.parse(RestClient.get(country['export_json_url']))
-      grouped_statements = statements.group_by { |s| s['position_item'] }
+      invalid_statements = statements.select { |s| s['position_item'].nil? }
+      grouped_statements = (statements - invalid_statements).group_by { |s| s['position_item'] }
       position_stats = grouped_statements.map do |position, position_statements|
         PositionStatistics.new(
           position:           position,
@@ -16,7 +17,7 @@ class StatementsStatistics
           existing_positions: existing_positions
         )
       end
-      [country['code'], position_stats]
+      [country['code'], [position_stats, invalid_statements]]
     end.to_h
   end
 

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -1,4 +1,4 @@
-<% @country_statements.each do |country_code, statements| %>
+<% @country_statements.each do |country_code, (statements, invalid_statements)| %>
   <h2>
     <% if country = @country_lookup[country_code.downcase] %>
       <%= link_to country.name, country %>
@@ -40,6 +40,30 @@
         <td><%= statement.correct %></td>
         <td><%= statement.incorrect %></td>
       </tr>
+    <% end %>
+    <% if invalid_statements.count > 0 %>
+    <tr>
+      <td colspan="5">
+        <details>
+          <summary>Invalid statements: <%= invalid_statements.count %></summary>
+
+          <table class="wikitable">
+            <tr>
+              <th>Transaction ID</th>
+              <th>Electoral District</th>
+              <th>Role code</th>
+            </tr>
+            <% invalid_statements.each do |statement| %>
+            <tr>
+              <td><%= statement['transaction_id'] %></td>
+              <td><a href="https://www.wikidata.org/wiki/<%= statement['electoral_district_item'] %>"><%= statement['electoral_district_item'] %></a></td>
+              <td><%= statement['role_code'] %></td>
+            </tr>
+            <% end %>
+          </table>
+        </details>
+      </td>
+    </tr>
     <% end %>
     </tbody>
   </table>

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe StatementsStatistics do
   describe '#statistics' do
     let! (:page) { create(:page, position_held_item: 'Q15964890') }
+
     before do
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/countries.json')
         .to_return(body: '[{"code": "ca", "export_json_url": "https://suggestions-store.mysociety.org/export/ca.json"}]')
@@ -24,13 +25,24 @@ describe StatementsStatistics do
           verification_status: 'incorrect',
           position_item:       'Q15964890',
         },
+        {
+          id:                  4,
+          verification_status: 'invalid',
+        },
       ]
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
         .to_return(body: JSON.generate(body))
     end
+
     it 'returns a hash of country stats' do
       statement_statistics = StatementsStatistics.new
-      position_stats = statement_statistics.statistics['ca'].first
+      statistics = statement_statistics.statistics['ca']
+
+      invalid_statement = statistics.last.first
+      expect(invalid_statement['id']).to eq(4)
+      expect(invalid_statement['verification_status']).to eq('invalid')
+
+      position_stats = statistics.first.first
       expect(position_stats.position).to eq('Q15964890')
       expect(position_stats.correct).to eq(2)
       expect(position_stats.incorrect).to eq(1)


### PR DESCRIPTION
Statements without `position_item` were being rendered incorrectly.

Added a details table showing the transaction, district and role. These
are used to get the position item from politician-data repo.

<img width="806" alt="screen shot 2018-08-24 at 13 58 14" src="https://user-images.githubusercontent.com/5426/44585913-6621df00-a79d-11e8-9845-9f9ab709ef17.png">
