### PR TITLE
[#418] Fix creation of equivalence claims

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -13,7 +13,7 @@ class StatementsController < FrontendController
   def statistics
     @country_statements = StatementsStatistics.new.statistics
     @country_lookup = Country.all.map { |c| [c.code, c] }.to_h
-    positions = @country_statements.values.flatten.map(&:position)
+    positions = @country_statements.values.map(&:first).flatten.map(&:position)
     @position_name_mapping = PositionNameMapping.new(positions: positions).mapping
   end
 

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -8,7 +8,8 @@ class StatementsStatistics
   def statistics
     countries.map do |country|
       statements = JSON.parse(RestClient.get(country['export_json_url']))
-      grouped_statements = statements.group_by { |s| s['position_item'] }
+      invalid_statements = statements.select { |s| s['position_item'].nil? }
+      grouped_statements = (statements - invalid_statements).group_by { |s| s['position_item'] }
       position_stats = grouped_statements.map do |position, position_statements|
         PositionStatistics.new(
           position:           position,
@@ -16,7 +17,7 @@ class StatementsStatistics
           existing_positions: existing_positions
         )
       end
-      [country['code'], position_stats]
+      [country['code'], [position_stats, invalid_statements]]
     end.to_h
   end
 

--- a/app/models/reconciliation.rb
+++ b/app/models/reconciliation.rb
@@ -63,7 +63,7 @@ class Reconciliation < ApplicationRecord
   end
 
   def create_equivalence_claim
-    return if resource_type != 'person' || !item_changed?
+    return if resource_type != 'person' || !item_previously_changed?
     store.create_equivalence_claim("Added FB ID for #{statement.person_name}")
   end
 

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -1,4 +1,4 @@
-<% @country_statements.each do |country_code, statements| %>
+<% @country_statements.each do |country_code, (statements, invalid_statements)| %>
   <h2>
     <% if country = @country_lookup[country_code.downcase] %>
       <%= link_to country.name, country %>
@@ -40,6 +40,30 @@
         <td><%= statement.correct %></td>
         <td><%= statement.incorrect %></td>
       </tr>
+    <% end %>
+    <% if invalid_statements.count > 0 %>
+    <tr>
+      <td colspan="5">
+        <details>
+          <summary>Invalid statements: <%= invalid_statements.count %></summary>
+
+          <table class="wikitable">
+            <tr>
+              <th>Transaction ID</th>
+              <th>Electoral District</th>
+              <th>Role code</th>
+            </tr>
+            <% invalid_statements.each do |statement| %>
+            <tr>
+              <td><%= statement['transaction_id'] %></td>
+              <td><a href="https://www.wikidata.org/wiki/<%= statement['electoral_district_item'] %>"><%= statement['electoral_district_item'] %></a></td>
+              <td><%= statement['role_code'] %></td>
+            </tr>
+            <% end %>
+          </table>
+        </details>
+      </td>
+    </tr>
     <% end %>
     </tbody>
   </table>

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe StatementsStatistics do
   describe '#statistics' do
     let! (:page) { create(:page, position_held_item: 'Q15964890') }
+
     before do
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/countries.json')
         .to_return(body: '[{"code": "ca", "export_json_url": "https://suggestions-store.mysociety.org/export/ca.json"}]')
@@ -24,13 +25,24 @@ describe StatementsStatistics do
           verification_status: 'incorrect',
           position_item:       'Q15964890',
         },
+        {
+          id:                  4,
+          verification_status: 'invalid',
+        },
       ]
       stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
         .to_return(body: JSON.generate(body))
     end
+
     it 'returns a hash of country stats' do
       statement_statistics = StatementsStatistics.new
-      position_stats = statement_statistics.statistics['ca'].first
+      statistics = statement_statistics.statistics['ca']
+
+      invalid_statement = statistics.last.first
+      expect(invalid_statement['id']).to eq(4)
+      expect(invalid_statement['verification_status']).to eq('invalid')
+
+      position_stats = statistics.first.first
       expect(position_stats.position).to eq('Q15964890')
       expect(position_stats.correct).to eq(2)
       expect(position_stats.incorrect).to eq(1)

--- a/spec/models/reconciliation_spec.rb
+++ b/spec/models/reconciliation_spec.rb
@@ -234,5 +234,26 @@ RSpec.describe Reconciliation, type: :model do
         end
       end
     end
+
+    context 'statement has FB identifier' do
+      let(:statement) do
+        # set initial person_item otherwise statement will attempt to fetch it
+        # from ID mapping store
+        create(:statement, person_item: 'Q1', fb_identifier: 'ABC')
+      end
+
+      before { reconciliation.resource_type = 'person' }
+
+      it 'should create equivalence claim' do
+        store = double('IDMappingStore')
+        expect(IDMappingStore).to receive(:new)
+          .with(wikidata_id: 'Q123', facebook_id: 'ABC')
+          .and_return(store)
+        expect(store).to receive(:create_equivalence_claim)
+
+        reconciliation.item = 'Q123'
+        reconciliation.save!
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes: #418 

Not sure why I thought this was working for me yesterday. Possible due to a bad spec and worst still my analysts of missing claims was incorrect and gave me a wrong impression of the issue :(

Once I proved my initial thinking that all claims since a [certain date](https://github.com/mysociety/verification-pages/issues/418#issuecomment-416914938) were effected it was easier to track down.

Error introduced in c3eb88579310911850a54a5727af5ace3d4cd519.

Sigh.