### PR TITLE
Allow creating verification pages on Wikidata

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,6 +11,15 @@ class PagesController < ApplicationController
     @pages = Page.all
   end
 
+  def setup
+    setup_wiki_page = SetupWikiPage.new(params[:page_title])
+    setup_wiki_page.run
+    redirect_to setup_wiki_page.redirect_url
+  rescue SetupWikiPage::Error => e
+    # FIXME: Better error handling needed.
+    render plain: "Error: #{e.message}", status: :bad_request
+  end
+
   # GET /pages/1
   def show
     @query = RetrievePositionData.new(

--- a/app/services/setup_wiki_page.rb
+++ b/app/services/setup_wiki_page.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class SetupWikiPage < ServiceBase
+  Error = Class.new(StandardError)
+
+  include WikiClient
+
+  def initialize(wiki_page_title)
+    @wiki_page_title = wiki_page_title
+  end
+
+  def run
+    page = Page.find_or_initialize_by(title: wiki_page_title)
+    page.assign_attributes(
+      country:            country,
+      position_held_item: settings[:position_held_item],
+      parliamentary_term_item: settings[:parliamentary_term_item],
+      csv_source_url:     settings[:csv_source_url]
+    )
+
+    raise Error, "Couldn't save the page" unless page.save
+
+    LoadStatements.run(page.title)
+    UpdateVerificationPage.run(page.title)
+  end
+
+  def redirect_url
+    "https://#{wiki_site}/wiki/#{wiki_page_title}"
+  end
+
+  private
+
+  attr_reader :wiki_page_title
+
+  def country
+    @country ||= Country.find_by(code: settings[:country_code])
+  end
+
+  def settings
+    @settings ||= JSON.parse(settings_json, symbolize_names: true)
+  end
+
+  def settings_json
+    @settings_json ||= client.get_wikitext(settings_json_title).body
+  end
+
+  def settings_json_title
+    wiki_page_title + '/settings.json'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   # Admin
   resources :countries
   resources :pages do
+    collection do
+      get :setup
+    end
+
     member do
       post :load
       post :create_wikidata

--- a/spec/services/setup_wiki_page_spec.rb
+++ b/spec/services/setup_wiki_page_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SetupWikiPage, type: :service do
+  let(:page_title) { 'Test_Page' }
+  subject { SetupWikiPage.new(page_title) }
+
+  before do
+    # Login
+    stub_request(:post, "https://#{ENV['WIKIDATA_SITE']}/w/api.php")
+      .to_return(body: '{"result":"Success"}')
+    # Get Test_Page/settings.json
+    stub_request(:get, "https://#{ENV['WIKIDATA_SITE']}/w/index.php?action=raw&title=#{page_title}/settings.json")
+      .to_return(body: JSON.generate(position_held_item: 'Q123', country_code: 'ca', csv_source_url: 'https://example.com/members.csv'))
+    create(:country, code: 'ca')
+    allow(LoadStatements).to receive(:run)
+    allow(UpdateVerificationPage).to receive(:run)
+  end
+
+  it 'creates a new page' do
+    expect { subject.run }.to change(Page, :count).by(1)
+  end
+
+  it 'runs the LoadStatements service' do
+    expect(LoadStatements).to receive(:run).with(page_title)
+    subject.run
+  end
+
+  it 'runs the UpdateVerificationPage service' do
+    expect(UpdateVerificationPage).to receive(:run).with(page_title)
+    subject.run
+  end
+
+  describe '#redirect_url' do
+    it 'is correct' do
+      expected = "https://#{ENV['WIKIDATA_SITE']}/wiki/#{page_title}"
+      expect(subject.redirect_url).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
I'm opening this pull request to get some feedback. Specifically I'd like to know:

1. Does this seem like a sensible approach?
2. Is there a better way we could do this?
3. Would a public off-wiki UI for creating pages be better than this approach?

I think it can probably be merged as-is and still provide _some_ benefits, but there are several issues that will need to be fixed pretty swiftly. See the "Problems" section below for more details about those.

Part of #330 

## Background

This adds a new service, along with a route to trigger it, which takes the title of a page on Wikidata and then generates a verification page for it. To configure the prompt the user has to add a subpage to the page where the prompt will live, called `/settings.json`. This is a settings file which configures the verification page.

## Testing information

I've been testing it with [the `{{ User:Chris_Mytton/sandbox/Template:Verification_page }}` template](https://www.wikidata.org/wiki/User:Chris_Mytton/sandbox/Template:Verification_page).

You can see this template in action at [wd:User:Verification_pages_bot/sandbox/Verification_test](https://www.wikidata.org/w/index.php?title=User:Verification_pages_bot/sandbox/Verification_test&oldid=732973144) (that links to an older version of the page currently the whole page gets overwritten when it's generated.

You can see an example `/settings.json` file at [wd:User:Verification_pages_bot/sandbox/Verification_test/settings.json](https://www.wikidata.org/wiki/User:Verification_pages_bot/sandbox/Verification_test/settings.json).

At the moment it can only create/update pages in the `User:Verification_pages_bot` namespace (if those are the credentials in your `.env`), because we haven't got a bot flag.

## Problems

- No documentation currently, need to write some so people know how to create a new page. This will probably be in Wikidata templates.
- Currently overwrites the original page (that contains the template tag) with the verification page
- Not all countries exist at the moment (need to bulk create all countries see #402)
- Slow to run (because it's done synchronously)
- Error handling is a bit lacking
- Hard to test manually because there's a lot of templates to setup initially
- Requires the use of JSON, so will need some kind of setup wizard for non-technical users to stand a chance of understanding it