### PR TITLE
On-wiki page creation using template parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.4.3
   - 2.5.0
 env:
-  - RAILS_ENV=test
+  - RAILS_ENV=test WIKIDATA_SITE=test.wikidata.org
 before_install:
   - gem update --system
   - cp config/database.yml.sample config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'redis-rails'
 gem 'id-mapper', github: 'mysociety/id-mapper'
 # Javascript runtime
 gem 'mini_racer'
+# Mediawiki template replacable content
+gem 'mediawiki-page-replaceable_content'
 
 group :development, :test do
   gem 'dotenv-rails', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
+    mediawiki-page-replaceable_content (0.1.3)
+      mediawiki_api (~> 0.7)
     mediawiki_api (0.7.1)
       faraday (~> 0.9, >= 0.9.0)
       faraday-cookie_jar (~> 0.0, >= 0.0.6)
@@ -311,6 +313,7 @@ DEPENDENCIES
   id-mapper!
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mediawiki-page-replaceable_content
   mediawiki_api
   mini_racer
   mysql2 (>= 0.3.18, < 0.6)

--- a/app/controllers/wikidata_page_controller.rb
+++ b/app/controllers/wikidata_page_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Controller to setup wikidata based verification pages
+class WikidataPageController < ApplicationController
+  def setup
+    @page = Page.find_or_initialize_by(title: params[:page_title])
+    wiki_page = WikiPageTemplateTag.new(@page.title)
+    if @page.update(wiki_page.page_attributes)
+      LoadStatements.run(@page.title)
+      wikitext = GenerateVerificationPage.run(@page.title)
+      wiki_page.update_page(wikitext)
+      redirect_to wiki_page.wikidata_url
+    else
+      render :wikidata_page_setup_error
+    end
+  end
+end

--- a/app/lib/wiki_page_template_tag.rb
+++ b/app/lib/wiki_page_template_tag.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'mediawiki/client'
+require 'mediawiki/page'
+
+class WikiPageTemplateTag
+  include WikiClient
+
+  def initialize(wiki_page_title)
+    @wiki_page_title = wiki_page_title
+  end
+
+  def page_attributes
+    {
+      country:                 country,
+      position_held_item:      params[:position_held_item],
+      parliamentary_term_item: params[:parliamentary_term_item],
+      csv_source_url:          params[:csv_source_url],
+    }
+  end
+
+  def update_page(content)
+    section.replace_output(content, 'Created or updated verification page')
+  end
+
+  def wikidata_url
+    "https://#{wiki_site}/wiki/#{wiki_page_title}"
+  end
+
+  private
+
+  attr_reader :wiki_page_title
+
+  def country
+    @country ||= Country.find_by(code: params[:country_code])
+  end
+
+  def params
+    section.params
+  end
+
+  def section
+    @section ||= MediaWiki::Page::ReplaceableContent.new(
+      client:   mediawiki_client,
+      title:    wiki_page_title,
+      template: wiki_template_name
+    )
+  end
+
+  def mediawiki_client
+    @mediawiki_client ||= MediaWiki::Client.new(
+      site:     wiki_site,
+      username: wiki_username,
+      password: wiki_password
+    )
+  end
+
+  def wiki_template_name
+    ENV.fetch('WIKI_TEMPLATE_NAME', 'Verification_page')
+  end
+end

--- a/app/views/wikidata_page/wikidata_page_setup_error.html.erb
+++ b/app/views/wikidata_page/wikidata_page_setup_error.html.erb
@@ -1,0 +1,21 @@
+<% if @page.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@page.errors.count, "error") %> prevented this page from being saved:</h2>
+
+    <ul>
+    <% @page.errors.messages.each do |field, messages| %>
+      <li>
+        <code><%= field %></code>: <%= messages.join(', ') %>
+        <% if field == :country %>
+          <p>Valid <code>country_code</code> options:</p>
+          <ul>
+            <% Country.all.each do |country| %>
+              <li><%= country.code %> (<%= country.name %>)</li>
+            <% end %>
+          </ul>
+        <% end %>
+      </li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   match '/api-proxy' => 'media_wiki_api#api_proxy', :via => %i[get post]
 
+  get 'wikidata-page-setup', to: 'wikidata_page#setup'
+
   get 'frontend', to: 'general#frontend'
   root 'general#index'
 end

--- a/spec/controllers/wikidata_page_controller_spec.rb
+++ b/spec/controllers/wikidata_page_controller_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WikidataPageController, type: :controller do
+  describe 'GET /setup' do
+    let!(:canada) { create(:country, code: 'ca') }
+    let(:wikidata_url) { 'https://www.wikidata.org/wiki/Test_Page' }
+    let(:wikipage) do
+      double(
+        WikiPageTemplateTag,
+        page_attributes: {
+          position_held_item:      'Q123',
+          country:                 canada,
+          parliamentary_term_item: 'Q456',
+          csv_source_url:          'https://example.com/members.csv',
+        },
+        update_page:     true,
+        wikidata_url:    wikidata_url
+      )
+    end
+
+    let(:valid_params) { { page_title: 'Test_Page' } }
+
+    before do
+      allow(WikiPageTemplateTag).to receive(:new).and_return(wikipage)
+      allow(LoadStatements).to receive(:run)
+      allow(GenerateVerificationPage).to receive(:run).and_return(double(wikitext: 'test text'))
+    end
+
+    it "creates a new page if there isn't an existing one" do
+      expect { get :setup, params: valid_params }.to change(Page, :count).by(1)
+    end
+
+    it 'uses existing page if there is one' do
+      create(:page, title: 'Test_Page')
+      expect { get :setup, params: valid_params }.to_not change(Page, :count)
+    end
+
+    it 'redirect to the wikidata URL' do
+      response = get :setup, params: valid_params
+      expect(response).to redirect_to(wikidata_url)
+    end
+
+    it "renders an error page if there's a problem updating the page" do
+      allow(wikipage).to receive(:page_attributes).and_return({})
+      response = get :setup, params: valid_params
+      expect(response).to render_template(:wikidata_page_setup_error)
+    end
+  end
+end

--- a/spec/lib/wiki_page_template_tag_spec.rb
+++ b/spec/lib/wiki_page_template_tag_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WikiPageTemplateTag, type: :service do
+  let(:page_title) { 'Test_Page' }
+
+  let(:wiki_template) do
+    <<~TEMPLATE
+      {{#{subject.send(:wiki_template_name)}
+      |country_code=ca
+      |position_held_item=Q123
+      |parliamentary_term_item=Q456
+      |csv_source_url=https://example.com/members.csv
+      }}
+    TEMPLATE
+  end
+
+  let(:api_url) do
+    "https://#{ENV['WIKIDATA_SITE']}/w/api.php"
+  end
+
+  let(:raw_wikitext_url) do
+    "https://#{ENV['WIKIDATA_SITE']}/w/index.php?action=raw&title=#{page_title}"
+  end
+
+  let(:csrftoken_url) do
+    "https://#{ENV['WIKIDATA_SITE']}/w/api.php?action=query&format=json&meta=tokens&type=csrf"
+  end
+
+  let!(:canada) do
+    create(:country, code: 'ca')
+  end
+
+  subject { WikiPageTemplateTag.new(page_title) }
+
+  before do
+    stub_request(:post, api_url).to_return(body: '{"result":"Success"}')
+    stub_request(:get, raw_wikitext_url).to_return(body: wiki_template)
+    stub_request(:get, csrftoken_url).to_return(body: '{"tokens":{"csrftoken":"foo"}}')
+    allow(subject).to receive(:wiki_username).and_return('test')
+    allow(subject).to receive(:wiki_password).and_return('test')
+  end
+
+  describe '#page_attributes' do
+    it 'parses the correct attributes from the template' do
+      expect(subject.page_attributes).to eq(
+        country:                 canada,
+        position_held_item:      'Q123',
+        parliamentary_term_item: 'Q456',
+        csv_source_url:          'https://example.com/members.csv'
+      )
+    end
+  end
+
+  describe '#update_page' do
+    let(:template_text) do
+      "#{wiki_template}test content\n<!-- OUTPUT END Created or updated verification page -->\n"
+    end
+
+    let(:expected_post_body) do
+      'action=edit&format=json&' \
+        "text=#{URI.encode_www_form_component(template_text)}&title=#{page_title}&token=foo"
+    end
+
+    it 'calls the Wikidata API and updates the page contents' do
+      subject.update_page('test content')
+      expect(WebMock).to have_requested(:post, api_url).with(body: expected_post_body)
+    end
+  end
+
+  describe '#wikidata_url' do
+    it 'is correct' do
+      expected = "https://#{ENV['WIKIDATA_SITE']}/wiki/#{page_title}"
+      expect(subject.wikidata_url).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new route which accepts the title of a Wikidata page, then uses that to fetch the page and search for a template tag configuring the verification page. This config is used to create or update a page with a matching title, then we load in the statements for that page and generate a verification page with it. Finally it redirects back to the original verification page, now fully setup.

Fixes #330 

## Features/problems ⚠️ 

- No documentation yet. Have opened https://github.com/mysociety/verification-pages/issues/431 to track this.
- Need to bulk create all countries #402 

## Testing instruction 🛠 

1. Check out this branch and get the server running
2. Add `WIKI_TEMPLATE_NAME=User:Chris_Mytton/sandbox/Template:Verification_page` to your `.env`
3. Change `WIKI_SITE` in `.env` to `www.wikidata.org`
4. Create a new page on Wikidata.org, I created https://www.wikidata.org/wiki/User:Chris_Mytton/sandbox/Verification_test, but I think it should work in any user namespace
5. Add this template to the new page:
```mediawiki
{{User:Chris_Mytton/sandbox/Template:Verification_page
|position_held_item=Q9045502
|parliamentary_term_item=Q55670426
|country_code=no
|csv_source_url=https://morph-csv-proxy.herokuapp.com/?scraper=everypolitician-scrapers/norway-stortinget-2017-wikipedia&query=select+name+as+person_name,+area+as+electoral_district_name,+id+as+person_item,+party_id+as+parliamentary_group_item,+party+as+parliamentary_group_name+from+data
}}
```
6. The page should now contain a button saying "Setup page", which should link to localhost:5000. Click that button.
7. Hopefully this has created a verification page 🤞 ☘️ 

## Notes to merger/deployer 📝 

When merging and deploying the following will need to be done:

- [ ] Create a top level template tag (`{{Verification page}}` probably makes sense) at https://www.wikidata.org/wiki/Template:Verification_page using the contents of https://www.wikidata.org/w/index.php?title=User:Chris_Mytton/sandbox/Template:Verification_page&action=edit and change the link to point to the live site.
- [ ] Bulk create all countries #402 