### PR TITLE
[#425] Detect when there are no matching P39

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -27,8 +27,28 @@ class StatementDecorator < SimpleDelegator
     latest_verification.nil? && matches_wikidata?
   end
 
+  def unverifiable?
+    unverifiable_due_to_party? ||
+      latest_verification && latest_verification.status == false
+  end
+
+  def recently_actioned?
+    # Was this statement actioned in the last 5 minutes?
+    return false unless actioned_at
+    time_difference_seconds = Time.zone.now - actioned_at
+    (time_difference_seconds / 60.0) < 5
+  end
+
   def done?
     verified? && matches_wikidata?
+  end
+
+  def verified?
+    latest_verification && latest_verification.status == true
+  end
+
+  def reconciled?
+    reconciliations.empty?
   end
 
   def problems
@@ -79,19 +99,6 @@ class StatementDecorator < SimpleDelegator
 
   def problem_reported?
     reported_at.present?
-  end
-
-  def unverifiable?
-    unverifiable_due_to_party? ||
-      latest_verification && latest_verification.status == false
-  end
-
-  def verified?
-    latest_verification && latest_verification.status == true
-  end
-
-  def reconciled?
-    reconciliations.empty?
   end
 
   def actioned?

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -97,7 +97,7 @@ class StatementDecorator < SimpleDelegator
         "There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - " \
         'one or more of them might be missing an end date or parliamentary term qualifier',
       ]
-    elsif actioned? && matching_position_held_data.empty?
+    elsif actioned_at? && matching_position_held_data.empty?
       ["There were no 'position held' (P39) statements on Wikidata that match the actioned suggestion"]
     else
       []
@@ -111,10 +111,6 @@ class StatementDecorator < SimpleDelegator
 
   def problem_reported?
     reported_at.present?
-  end
-
-  def actioned?
-    actioned_at?
   end
 
   def reconciliations

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -43,6 +43,18 @@ class StatementDecorator < SimpleDelegator
     verified? && matches_wikidata?
   end
 
+  def reverted?
+    !done? && (actioned_at? && data.present?)
+  end
+
+  def manually_actionable?
+    !reverted? && (reconciled? && !problems.empty?)
+  end
+
+  def actionable?
+    !manually_actionable? && (verified? && reconciled?)
+  end
+
   def verified?
     latest_verification && latest_verification.status == true
   end

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -32,8 +32,8 @@ class StatementDecorator < SimpleDelegator
   end
 
   def problems
-    if multiple_statement_problems.any?
-      multiple_statement_problems
+    if statement_problems.any?
+      statement_problems
     else
       electoral_district_problems +
         parliamentary_group_problems +
@@ -59,9 +59,14 @@ class StatementDecorator < SimpleDelegator
     ["The parliamentary group (party) is different in the statement (#{parliamentary_group_item}) and on Wikidata (#{data&.group})"]
   end
 
-  def multiple_statement_problems
-    return [] unless matching_position_held_data.length > 1
-    ["There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier"]
+  def statement_problems
+    if matching_position_held_data.length > 1
+      ["There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier"]
+    elsif actioned? && matching_position_held_data.empty?
+      ["There were no 'position held' (P39) statements on Wikidata that match the actioned suggestion"]
+    else
+      []
+    end
   end
 
   def reported_problems

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -61,7 +61,10 @@ class StatementDecorator < SimpleDelegator
 
   def statement_problems
     if matching_position_held_data.length > 1
-      ["There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier"]
+      [
+        "There were #{matching_position_held_data.length} 'position held' (P39) statements on Wikidata that match the verified suggestion - " \
+        'one or more of them might be missing an end date or parliamentary term qualifier',
+      ]
     elsif actioned? && matching_position_held_data.empty?
       ["There were no 'position held' (P39) statements on Wikidata that match the actioned suggestion"]
     else

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -40,13 +40,6 @@ class Statement < ApplicationRecord
     save!
   end
 
-  def recently_actioned?
-    # Was this statement actioned in the last 5 minutes?
-    return false unless actioned_at
-    time_difference_seconds = Time.now - actioned_at
-    (time_difference_seconds / 60.0) < 5
-  end
-
   def duplicate_statements
     Statement.where(
       page:                    page,

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -80,7 +80,7 @@ class StatementClassifier
       :done
     elsif statement.done?
       :done
-    elsif statement.actioned?
+    elsif statement.actioned? && statement.data
       :reverted
     elsif statement.reconciled? && !statement.problems.empty?
       :manually_actionable

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -80,11 +80,11 @@ class StatementClassifier
       :done
     elsif statement.done?
       :done
-    elsif statement.actioned? && statement.data
+    elsif statement.reverted?
       :reverted
-    elsif statement.reconciled? && !statement.problems.empty?
+    elsif statement.manually_actionable?
       :manually_actionable
-    elsif statement.verified? && statement.reconciled?
+    elsif statement.actionable?
       :actionable
     elsif statement.verified?
       :reconcilable

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe StatementDecorator, type: :decorator do
       let(:expected_error) do
         'There were no \'position held\' (P39) statements on Wikidata that match the actioned suggestion'
       end
-      before { allow(statement).to receive(:actioned?).and_return(true) }
+      before { allow(statement).to receive(:actioned_at?).and_return(true) }
       it 'should find a problem with there being no matching statements' do
         expect(statement.statement_problems).to eq([expected_error])
       end

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -32,7 +32,18 @@ RSpec.describe StatementDecorator, type: :decorator do
         'There were 2 \'position held\' (P39) statements on Wikidata that match the verified suggestion - one or more of them might be missing an end date or parliamentary term qualifier'
       end
       it 'should find a problem with there being multiple matching statements' do
-        expect(statement.multiple_statement_problems).to eq([expected_error])
+        expect(statement.statement_problems).to eq([expected_error])
+      end
+    end
+
+    context 'when there are no matching statements' do
+      let(:matching_position_held_data) { [] }
+      let(:expected_error) do
+        'There were no \'position held\' (P39) statements on Wikidata that match the actioned suggestion'
+      end
+      before { allow(statement).to receive(:actioned?).and_return(true) }
+      it 'should find a problem with there being no matching statements' do
+        expect(statement.statement_problems).to eq([expected_error])
       end
     end
 

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -262,6 +262,22 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.reverted).to be_empty }
     end
 
+    context 'when statement has been actioned by has no matching Wikidata P39' do
+      let(:position_held_data) { [] }
+      before do
+        statement.verifications.build(status: true)
+        allow(statement).to receive(:person_item).and_return('Q1')
+        allow(statement).to receive(:actioned_at?).and_return(true)
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to eq(statements) }
+      it { expect(classifier.done).to be_empty }
+      it { expect(classifier.reverted).to be_empty }
+    end
+
     context 'when the statement has been actioned' do
       before do
         statement.verifications.build(status: true)


### PR DESCRIPTION
Fixes #425

If a statement has been actioned and there are no P39 then something has
gone wrong. In this case we want to have the statement in the manually
actionable state we know to investigate it.