### PR TITLE
[#238] Only compare common fields

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -87,6 +87,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def parliamentary_group_problems
+    return [] if parliamentary_group_item.blank?
     return [] unless data&.group && parliamentary_group_item != data&.group
     ["The parliamentary group (party) is different in the statement (#{parliamentary_group_item}) and on Wikidata (#{data&.group})"]
   end

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -237,6 +237,32 @@ RSpec.describe StatementDecorator, type: :decorator do
         expect(statement.problems).to eq([])
       end
     end
+
+    context 'when a source contains no parliamentary group information' do
+      let(:object) do
+        build(
+          :statement,
+          person_item:             'Q1',
+          electoral_district_item: 'Q345',
+          electoral_district_name: 'Somewhereville'
+        )
+      end
+      let(:matching_position_held_data) do
+        [
+          OpenStruct.new(
+            revision:       '123',
+            position:       'UUID',
+            position_start: '2014-01-31',
+            term_start:     '2014-01-31',
+            district:       'Q345',
+            group:          'Q123'
+          ),
+        ]
+      end
+      it 'should not report any problems with district' do
+        expect(statement.problems).to eq([])
+      end
+    end
   end
 
   describe '#reconciliations' do

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -423,6 +423,32 @@ RSpec.describe StatementClassifier, type: :service do
       it { expect(classifier.reverted).to be_empty }
     end
 
+    context 'when statement has no parliamentary group but Wikidata does and everything else matches' do
+      let(:page) do
+        build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')
+      end
+      let(:data) do
+        { person_item:             'Q1',
+          electoral_district_item: 'Q4', }
+      end
+      let(:wikidata_data) do
+        { person:              'Q1',
+          merged_then_deleted: '',
+          term:                'Q2',
+          term_start:          '2018-01-01',
+          position_start:      '2018-01-01',
+          group:               'Q3',
+          district:            'Q4', }
+      end
+      it { expect(classifier.verifiable).to be_empty }
+      it { expect(classifier.unverifiable).to be_empty }
+      it { expect(classifier.reconcilable).to be_empty }
+      it { expect(classifier.actionable).to be_empty }
+      it { expect(classifier.manually_actionable).to be_empty }
+      it { expect(classifier.done).to eq(statements) }
+      it { expect(classifier.reverted).to be_empty }
+    end
+
     context 'when statement has no district but Wikidata does and everything else matches' do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')


### PR DESCRIPTION
Connects to #238 

Similar to #308 

This adds a check to ignore any problems with parliamentary group if that data wasn't provided in the source CSV. Previously it would have complained that the source didn't match Wikidata.