### PR TITLE
Fix FactoryBot deprecation warnings

### DIFF
--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :country do
-    name 'Canada'
-    code 'ca'
-    description_en 'Canadian politician'
-    label_lang 'en'
-    wikidata_id 'Q16'
+    name { 'Canada' }
+    code { 'ca' }
+    description_en { 'Canadian politician' }
+    label_lang { 'en' }
+    wikidata_id { 'Q16' }
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -6,9 +6,9 @@ FactoryBot.define do
   end
   factory :page do
     title
-    position_held_item 'Q1'
-    reference_url 'http://example.com'
-    csv_source_url 'https://example.com/export.csv'
+    position_held_item { 'Q1' }
+    reference_url { 'http://example.com' }
+    csv_source_url { 'https://example.com/export.csv' }
     country
   end
 end

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :statement do
     page
-    transaction_id '123'
+    transaction_id { '123' }
   end
 
   factory :statement_with_names, class: Statement do


### PR DESCRIPTION
`Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead`

Missed these when I merged #405