### PR TITLE
[#157] Add parliamentary term name

### DIFF
--- a/app/javascript/components/statement_change_summary.html
+++ b/app/javascript/components/statement_change_summary.html
@@ -13,7 +13,8 @@
   </li>
   <li>'parliamentary term' qualifier:
     <wikilink :id="statement.parliamentary_term_item">
-      {{ statement.parliamentary_term_item }}
+      {{ statement.parliamentary_term_name }}
+      ({{ statement.parliamentary_term_item }})
     </wikilink>
   </li>
   <li>'reference URL' qualifier:

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -10,7 +10,24 @@ class Page < ApplicationRecord
   validates :reference_url, length: { maximum: 2000 }
   validates :csv_source_url, presence: true
 
+  before_validation :set_position_held_name, if: :position_held_item_changed?
+  before_validation :set_parliamentary_term_name, if: :parliamentary_term_item_changed?
+
   def from_suggestions_store?
     /^#{Regexp.escape(ENV.fetch('SUGGESTIONS_STORE_URL'))}/.match?(csv_source_url)
+  end
+
+  private
+
+  def set_position_held_name
+    self.position_held_name = page_data&.position_name
+  end
+
+  def set_parliamentary_term_name
+    self.parliamentary_term_name = page_data&.term_name
+  end
+
+  def page_data
+    @page_data ||= RetrievePageData.run(position_held_item, parliamentary_term_item)
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -13,7 +13,7 @@ class Statement < ApplicationRecord
   before_create :detect_duplicate_statements, :retrieve_wikidata_id
   after_create :verify_duplicate!, if: :duplicate?
 
-  delegate :parliamentary_term_item, to: :page
+  delegate :parliamentary_term_item, :parliamentary_term_name, to: :page
 
   def latest_verification
     verifications.last

--- a/app/services/retrieve_page_data.rb
+++ b/app/services/retrieve_page_data.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Service to fetch position term data from a SPARQL query
+class RetrievePageData < ServiceBase
+  include SparqlQuery
+
+  attr_reader :position, :term
+
+  def initialize(position, term)
+    @position = position
+    @term = term
+  end
+
+  def run
+    run_query(query).first
+  end
+
+  def query
+    query_format % { position: position, term: term }
+  end
+
+  private
+
+  def query_format
+    <<~SPARQL
+      SELECT DISTINCT
+        ?position ?position_name
+        ?term ?term_name
+      WHERE {
+        BIND(wd:%<position>s AS ?position)
+        BIND(wd:%<term>s AS ?term)
+        ?position rdfs:label ?position_name filter (lang(?position_name) = "en") .
+        ?term rdfs:label ?term_name filter (lang(?term_name) = "en") .
+      }
+    SPARQL
+  end
+end

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -11,9 +11,9 @@
   <dt><strong><%= model_class.human_attribute_name(:title) %>:</strong></dt>
   <dd><%= @page.title %></dd>
   <dt><strong><%= model_class.human_attribute_name(:position_held_item) %>:</strong></dt>
-  <dd><%= @page.position_held_item %></dd>
+  <dd><%= @page.position_held_name %> (<%= @page.position_held_item %>)</dd>
   <dt><strong><%= model_class.human_attribute_name(:parliamentary_term_item) %>:</strong></dt>
-  <dd><%= @page.parliamentary_term_item %></dd>
+  <dd><%= @page.parliamentary_term_name %> (<%= @page.parliamentary_term_item %>)</dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= @page.reference_url %></dd>
   <!--

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -16,6 +16,7 @@ json.statements @classifier.to_a do |statement|
     :person_name,
     :parliamentary_group_name,
     :electoral_district_name,
+    :parliamentary_term_name,
     :problems,
     :problem_reported?,
     :reconciliations

--- a/db/migrate/20180910092202_add_position_and_term_names_to_pages.rb
+++ b/db/migrate/20180910092202_add_position_and_term_names_to_pages.rb
@@ -1,0 +1,6 @@
+class AddPositionAndTermNamesToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :position_held_name, :string
+    add_column :pages, :parliamentary_term_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_17_110527) do
+ActiveRecord::Schema.define(version: 2018_09_10_092202) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 2018_08_17_110527) do
     t.boolean "executive_position", default: false, null: false
     t.string "reference_url_title"
     t.string "reference_url_language"
+    t.string "position_held_name"
+    t.string "parliamentary_term_name"
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -27,6 +27,48 @@ RSpec.describe Page, type: :model do
     end
   end
 
+  describe 'before validation' do
+    let(:page) { build(:page, position_held_item: 'Q2', parliamentary_term_item: 'Q3') }
+
+    before do
+      allow(RetrievePageData).to receive(:run).with('Q2', 'Q3').and_return(
+        OpenStruct.new(position_name: 'Position', term_name: 'Term')
+      )
+    end
+
+    context 'position held item changed' do
+      before { allow(page).to receive(:position_held_item_changed?) { true } }
+
+      it 'should set position held name' do
+        expect { page.valid? }.to change(page, :position_held_name).to('Position')
+      end
+    end
+
+    context 'position held item is unchanged' do
+      before { allow(page).to receive(:position_held_item_changed?) { false } }
+
+      it 'should not set position held name' do
+        expect { page.valid? }.to_not change(page, :position_held_name)
+      end
+    end
+
+    context 'parliamentary term item changed' do
+      before { allow(page).to receive(:parliamentary_term_item_changed?) { true } }
+
+      it 'should set parliamentary term name' do
+        expect { page.valid? }.to change(page, :parliamentary_term_name).to('Term')
+      end
+    end
+
+    context 'position held item is unchanged' do
+      before { allow(page).to receive(:parliamentary_term_item_changed?) { false } }
+
+      it 'should not set position held name' do
+        expect { page.valid? }.to_not change(page, :parliamentary_term_name)
+      end
+    end
+  end
+
   describe '#from_suggestions_store?' do
     it 'knows that it came from suggestions-store' do
       page = create(:page, csv_source_url: "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/blah.csv")

--- a/spec/services/retrieve_page_data_spec.rb
+++ b/spec/services/retrieve_page_data_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RetrievePageData, type: :service do
+  let(:service) { RetrievePageData.new('Q1', 'Q2') }
+
+  describe 'initialisation' do
+    it 'assigns position instance variable' do
+      expect(service.position).to eq 'Q1'
+    end
+
+    it 'assigns term instance variable' do
+      expect(service.term).to eq 'Q2'
+    end
+  end
+
+  describe '#run' do
+    it 'calls run_query with substituted position' do
+      allow(service).to receive(:query_format).and_return('%<position>s')
+      expect(service).to receive(:run_query).with('Q1').and_return([])
+      service.run
+    end
+
+    it 'calls run_query with substituted term' do
+      allow(service).to receive(:query_format).and_return('%<term>s')
+      expect(service).to receive(:run_query).with('Q2').and_return([])
+      service.run
+    end
+
+    it 'returns the first result' do
+      allow(service).to receive(:run_query).and_return(%w[foo bar])
+      expect(service.run).to eq 'foo'
+    end
+  end
+end

--- a/spec/support/page_setup.rb
+++ b/spec/support/page_setup.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before do
+    allow(RetrievePageData).to receive(:run).and_return(nil)
+  end
+end


### PR DESCRIPTION
Fixes #157 

This retrieves names for parliamentary term and the position held Wikidata items and caches them on the Page model when a page created or updated.

We show these in the statement change summary and the admin pages#show action.