### PR TITLE
[#316] Classify statements as `removed` if they vanish from source

### DIFF
--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -63,7 +63,7 @@ class StatementDecorator < SimpleDelegator
   end
 
   def reconciled?
-    reconciliations.empty?
+    reconciliations_required.empty?
   end
 
   def problems
@@ -117,7 +117,7 @@ class StatementDecorator < SimpleDelegator
     reported_at.present?
   end
 
-  def reconciliations
+  def reconciliations_required
     person_reconciliations + party_reconciliations + district_reconciliations
   end
 

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -41,7 +41,9 @@ class StatementDecorator < SimpleDelegator
   end
 
   def done?
-    verified? && matches_wikidata?
+    recently_actioned? ||
+      (verified? && matches_wikidata?) ||
+      (!from_suggestions_store? && matches_but_not_checked?)
   end
 
   def reverted?

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -50,6 +50,10 @@ class StatementDecorator < SimpleDelegator
     !done? && (actioned_at? && data.present?)
   end
 
+  def done_or_reverted?
+    done? || reverted?
+  end
+
   def manually_actionable?
     !reverted? && (reconciled? && !problems.empty?)
   end

--- a/app/javascript/components/removed.html
+++ b/app/javascript/components/removed.html
@@ -1,0 +1,8 @@
+<span>
+  This statement was actioned, but has since been removed from the upstream
+  source. You should verify the statement to see if:
+  <ul>
+    <li>an end date (P582) should be added</li>
+    <li>it's incorrect and should removed completely.</li>
+  </ul>
+</span>

--- a/app/javascript/components/removed.js
+++ b/app/javascript/components/removed.js
@@ -1,0 +1,9 @@
+import template from './removed.html'
+
+export default template({
+  data () { return {} },
+  props: ['statement', 'page', 'country'],
+  created: function () {
+    this.statement.bulk_update = false
+  }
+})

--- a/app/javascript/components/statement.js
+++ b/app/javascript/components/statement.js
@@ -8,6 +8,7 @@ import actionableComponent from './actionable'
 import manuallyActionableComponent from './manually_actionable'
 import doneComponent from './done'
 import revertedComponent from './reverted'
+import removedComponent from './removed'
 
 export default template({
   data () {
@@ -29,6 +30,7 @@ export default template({
         case 'manually_actionable': return manuallyActionableComponent
         case 'done': return doneComponent
         case 'reverted': return revertedComponent
+        case 'removed': return removedComponent
       }
     },
     stylingClass: function () {

--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -11,39 +11,46 @@ class LoadStatements < ServiceBase
   end
 
   def run
-    csv.map do |result|
-      result[:transaction_id] ||= generate_transaction_id(result)
-
-      statement = Statement.find_or_initialize_by(
-        transaction_id: result[:transaction_id]
-      )
-
-      # We need to be careful not wipe out any manually reconciled
-      # items when refreshing from the upstream CSV file, so don't
-      # overwrite the *_item attributes if that'd make them blank:
-      Reconciliation.resource_mappings.each do |type, attributes|
-        attribute = attributes[:item]
-        reconciliation = statement.reconciliations
-                                  .where(resource_type: type)
-                                  .last
-        value = reconciliation ? reconciliation.item : result[attribute]
-        statement.public_send("#{attribute}=", value) if value.present?
-      end
-
-      # The other attributes we always update from the upstream CSV:
-      statement.update!(
-        page:                     page,
-        person_name:              result[:person_name],
-        electoral_district_name:  result[:electoral_district_name],
-        parliamentary_group_name: result[:parliamentary_group_name],
-        fb_identifier:            result[:fb_identifier],
-        position_start:           result[:position_start],
-        position_end:             result[:position_end]
-      )
-    end
+    touched_statements = csv.map { |result| parse_result(result) }
+    untouched_statements = page.statements.where.not(id: touched_statements)
+    untouched_statements.update(removed_from_source: true)
   end
 
   private
+
+  def parse_result(result)
+    result[:transaction_id] ||= generate_transaction_id(result)
+
+    statement = page.statements.find_or_initialize_by(
+      transaction_id: result[:transaction_id]
+    )
+
+    # We need to be careful not wipe out any manually reconciled
+    # items when refreshing from the upstream CSV file, so don't
+    # overwrite the *_item attributes if that'd make them blank:
+    Reconciliation.resource_mappings.each do |type, attributes|
+      attribute = attributes[:item]
+      reconciliation = statement.reconciliations
+                                .where(resource_type: type)
+                                .last
+      value = reconciliation ? reconciliation.item : result[attribute]
+      statement.public_send("#{attribute}=", value) if value.present?
+    end
+
+    # The other attributes we always update from the upstream CSV:
+    statement.update!(
+      page:                     page,
+      person_name:              result[:person_name],
+      electoral_district_name:  result[:electoral_district_name],
+      parliamentary_group_name: result[:parliamentary_group_name],
+      fb_identifier:            result[:fb_identifier],
+      position_start:           result[:position_start],
+      position_end:             result[:position_end],
+      removed_from_source:      false
+    )
+
+    statement
+  end
 
   def csv
     @csv ||= CSV.parse(raw_data, headers: true, header_converters: :symbol,

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -73,9 +73,9 @@ class StatementClassifier
   end
 
   def statement_type(statement)
-    if statement.removed_from_source? && !statement.done?
+    if statement.removed_from_source? && !statement.done_or_reverted?
       nil
-    elsif statement.removed_from_source? && statement.done?
+    elsif statement.removed_from_source? && statement.done_or_reverted?
       :removed
     elsif statement.unverifiable?
       :unverifiable

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -76,8 +76,6 @@ class StatementClassifier
   def statement_type(statement)
     if statement.unverifiable?
       :unverifiable
-    elsif statement.recently_actioned?
-      :done
     elsif statement.done?
       :done
     elsif statement.reverted?
@@ -88,8 +86,6 @@ class StatementClassifier
       :actionable
     elsif statement.verified?
       :reconcilable
-    elsif !statement.from_suggestions_store? && statement.matches_but_not_checked?
-      :done
     else
       :verifiable
     end

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -18,8 +18,7 @@ json.statements @classifier.to_a do |statement|
     :electoral_district_name,
     :parliamentary_term_name,
     :problems,
-    :problem_reported?,
-    :reconciliations
+    :problem_reported?
   )
 
   if statement.latest_verification

--- a/db/migrate/20180911085714_add_removed_from_source_to_statements.rb
+++ b/db/migrate/20180911085714_add_removed_from_source_to_statements.rb
@@ -1,0 +1,5 @@
+class AddRemovedFromSourceToStatements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :statements, :removed_from_source, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2018_09_13_111831) do
     t.timestamp "reported_at"
     t.date "position_start"
     t.date "position_end"
+    t.boolean "removed_from_source", default: false
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 

--- a/spec/decorators/statement_decorator_spec.rb
+++ b/spec/decorators/statement_decorator_spec.rb
@@ -265,11 +265,11 @@ RSpec.describe StatementDecorator, type: :decorator do
     end
   end
 
-  describe '#reconciliations' do
+  describe '#reconciliations_required' do
     let(:page) { build(:page) }
     let(:object) { build(:statement, person_item: 'Q1', page: page) }
 
-    subject { statement.reconciliations }
+    subject { statement.reconciliations_required }
 
     context 'when person has been reconciled' do
       before { statement.person_item = 'Q1' }

--- a/spec/factories/statements.rb
+++ b/spec/factories/statements.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :statement do
     page
-    transaction_id { '123' }
+    sequence(:transaction_id) { |n| 123 + n }
   end
 
   factory :statement_with_names, class: Statement do

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -46,6 +46,24 @@ RSpec.describe StatementClassifier, type: :service do
     end
   end
 
+  RSpec.shared_examples 'classified as' do |current_state|
+    %w[
+      verifiable unverifiable reconcilable
+      actionable manually_actionable done
+      reverted
+    ].each do |state|
+      if state == current_state
+        it "should be classified as #{state}" do
+          expect(classifier.public_send(state)).to eq(statements)
+        end
+      else
+        it "should not be classified as #{state}" do
+          expect(classifier.public_send(state)).to be_empty
+        end
+      end
+    end
+  end
+
   describe 'statement classification' do
     let(:data) do
       { person_item:              '',
@@ -64,26 +82,12 @@ RSpec.describe StatementClassifier, type: :service do
     end
 
     context 'when verifiable' do
-      it { expect(classifier.verifiable).to eq(statements) }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+      include_examples 'classified as', 'verifiable'
     end
 
     context 'when unverifiable' do
-      before do
-        statement.verifications.build(status: false)
-      end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to eq(statements) }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+      before { statement.verifications.build(status: false) }
+      include_examples 'classified as', 'unverifiable'
     end
 
     context 'when unverifiable (although otherwise would be marked "manually actionable")' do
@@ -92,24 +96,13 @@ RSpec.describe StatementClassifier, type: :service do
         allow(statement).to receive(:person_item).and_return('Q1')
         position_held.district = 'other-district'
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to eq(statements) }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'unverifiable'
     end
 
     context 'when verified' do
       before { statement.verifications.build(status: true) }
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to eq(statements) }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+      include_examples 'classified as', 'reconcilable'
     end
 
     context 'when statement is actionable' do
@@ -118,13 +111,8 @@ RSpec.describe StatementClassifier, type: :service do
         statement.verifications.build(status: true)
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to eq(statements) }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'actionable'
     end
 
     context 'when statement is actionable, but has been actioned in the last 5 minutes' do
@@ -138,16 +126,12 @@ RSpec.describe StatementClassifier, type: :service do
         allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
         allow(statement).to receive(:actioned_at?).and_return(true)
       end
+
       after do
         travel_back
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when statement would be actionable, but has been actioned over 5 minutes ago' do
@@ -161,16 +145,12 @@ RSpec.describe StatementClassifier, type: :service do
         allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
         allow(statement).to receive(:actioned_at?).and_return(true)
       end
+
       after do
         travel_back
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to eq(statements) }
+
+      include_examples 'classified as', 'reverted'
     end
 
     context 'when district qualifier contradict' do
@@ -178,13 +158,8 @@ RSpec.describe StatementClassifier, type: :service do
         position_held.district = 'other-district'
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to eq(statements) }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'manually_actionable'
     end
 
     context 'when group qualifier contradict' do
@@ -192,13 +167,8 @@ RSpec.describe StatementClassifier, type: :service do
         position_held.group = 'other-group'
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to eq(statements) }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'manually_actionable'
     end
 
     context 'when position start is more than 31 days before term start' do
@@ -207,13 +177,8 @@ RSpec.describe StatementClassifier, type: :service do
         position_held.position_start = '2017-11-05'
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to eq(statements) }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'manually_actionable'
     end
 
     context 'when statement has been reported' do
@@ -222,29 +187,20 @@ RSpec.describe StatementClassifier, type: :service do
         allow(statement).to receive(:reported_at).and_return(Time.zone.now)
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to eq(statements) }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'manually_actionable'
     end
 
     context 'when statement has been actioned by has no matching Wikidata P39' do
       let(:position_held_data) { [] }
+
       before do
         statement.verifications.build(status: true)
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at?).and_return(true)
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to eq(statements) }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'manually_actionable'
     end
 
     context 'when the statement has been actioned' do
@@ -252,24 +208,13 @@ RSpec.describe StatementClassifier, type: :service do
         statement.verifications.build(status: true)
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when there are not any statements' do
       let(:statement) { nil }
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+      include_examples 'classified as', nil # not classified at all
     end
 
     context 'when the reconciled person has since been merged into someone else' do
@@ -287,65 +232,48 @@ RSpec.describe StatementClassifier, type: :service do
           group:               'Q3',
           district:            'Q4', }
       end
+
       before do
         statement.verifications.build(status: true)
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when the statements are reconciled but not verified' do
       before do
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to eq(statements) }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'verifiable'
     end
 
     context 'when the statement is from suggestions-store and is already correct (apart from the reference) in Wikidata' do
       before do
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to eq(statements) }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to be_empty }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'verifiable'
     end
 
     context 'when the statement is not from suggestions-store and is already correct in Wikidata' do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')
       end
+
       before do
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context "when the Wikidata item has no district and the statement's page has executive_position = true set" do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', executive_position: true)
       end
+
       let(:wikidata_data) do
         { person:              'Q1',
           merged_then_deleted: '',
@@ -355,22 +283,19 @@ RSpec.describe StatementClassifier, type: :service do
           group:               'Q3',
           district:            nil, }
       end
+
       before do
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context "when the Wikidata item has no group and the statement's page has executive_position = true set" do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', executive_position: true)
       end
+
       let(:wikidata_data) do
         { person:              'Q1',
           merged_then_deleted: '',
@@ -380,26 +305,24 @@ RSpec.describe StatementClassifier, type: :service do
           group:               nil,
           district:            'Q4', }
       end
+
       before do
         allow(statement).to receive(:person_item).and_return('Q1')
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when statement has no parliamentary group but Wikidata does and everything else matches' do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')
       end
+
       let(:data) do
         { person_item:             'Q1',
           electoral_district_item: 'Q4', }
       end
+
       let(:wikidata_data) do
         { person:              'Q1',
           merged_then_deleted: '',
@@ -409,24 +332,21 @@ RSpec.describe StatementClassifier, type: :service do
           group:               'Q3',
           district:            'Q4', }
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when statement has no district but Wikidata does and everything else matches' do
       let(:page) do
         build(:page, parliamentary_term_item: 'Q2', csv_source_url: 'http://example.com/politicians.csv')
       end
+
       let(:data) do
         { person_item:              'Q1',
           parliamentary_group_item: 'Q3',
           electoral_district_item:  nil, }
       end
+
       let(:wikidata_data) do
         { person:              'Q1',
           merged_then_deleted: '',
@@ -436,24 +356,21 @@ RSpec.describe StatementClassifier, type: :service do
           group:               'Q3',
           district:            'Q4', }
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
 
     context 'when statement page has no term and everything else matches' do
       let(:page) do
         build(:page, parliamentary_term_item: '', csv_source_url: 'http://example.com/politicians.csv')
       end
+
       let(:data) do
         { person_item:              'Q1',
           parliamentary_group_item: 'Q3',
           electoral_district_item:  nil, }
       end
+
       let(:wikidata_data) do
         { person:              'Q1',
           merged_then_deleted: '',
@@ -463,18 +380,14 @@ RSpec.describe StatementClassifier, type: :service do
           group:               'Q3',
           district:            'Q4', }
       end
+
       before do
         statement.verifications.build(status: true)
         allow(statement).to receive(:actioned_at).and_return(Time.now - 10.minutes)
         allow(statement).to receive(:actioned_at?).and_return(true)
       end
-      it { expect(classifier.verifiable).to be_empty }
-      it { expect(classifier.unverifiable).to be_empty }
-      it { expect(classifier.reconcilable).to be_empty }
-      it { expect(classifier.actionable).to be_empty }
-      it { expect(classifier.manually_actionable).to be_empty }
-      it { expect(classifier.done).to eq(statements) }
-      it { expect(classifier.reverted).to be_empty }
+
+      include_examples 'classified as', 'done'
     end
   end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -395,6 +395,18 @@ RSpec.describe StatementClassifier, type: :service do
       include_examples 'classified as', 'removed'
     end
 
+    context 'when statement is reverted but has been removed from source' do
+      before do
+        statement.removed_from_source = true
+        position_held.group = nil
+        allow(statement).to receive(:person_item).and_return('Q1')
+        allow(statement).to receive(:actioned_at).and_return(5.minutes.ago)
+        allow(statement).to receive(:actioned_at?).and_return(true)
+      end
+
+      include_examples 'classified as', 'removed'
+    end
+
     context 'when statement has been remvoed from source before being verified' do
       before { statement.removed_from_source = true }
       include_examples 'classified as', nil # not classified at all

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe StatementClassifier, type: :service do
       include_examples 'classified as', 'verifiable'
     end
 
+    context 'when the statements are reconciled but not verified' do
+      before do
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+
+      include_examples 'classified as', 'verifiable'
+    end
+
+    context 'when the statement is from suggestions-store and is already correct (apart from the reference) in Wikidata' do
+      before do
+        allow(statement).to receive(:person_item).and_return('Q1')
+      end
+
+      include_examples 'classified as', 'verifiable'
+    end
+
     context 'when unverifiable' do
       before { statement.verifications.build(status: false) }
       include_examples 'classified as', 'unverifiable'
@@ -113,44 +129,6 @@ RSpec.describe StatementClassifier, type: :service do
       end
 
       include_examples 'classified as', 'actionable'
-    end
-
-    context 'when statement is actionable, but has been actioned in the last 5 minutes' do
-      before do
-        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
-        travel_to supposed_current_time
-        # 3 minutes before that:
-        supposed_actioned_at_time = supposed_current_time - 3.0 / (24 * 60)
-        position_held.group = nil
-        allow(statement).to receive(:person_item).and_return('Q1')
-        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
-        allow(statement).to receive(:actioned_at?).and_return(true)
-      end
-
-      after do
-        travel_back
-      end
-
-      include_examples 'classified as', 'done'
-    end
-
-    context 'when statement would be actionable, but has been actioned over 5 minutes ago' do
-      before do
-        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
-        travel_to supposed_current_time
-        # 10 minutes before that:
-        supposed_actioned_at_time = supposed_current_time - 10.0 / (24 * 60)
-        position_held.group = nil
-        allow(statement).to receive(:person_item).and_return('Q1')
-        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
-        allow(statement).to receive(:actioned_at?).and_return(true)
-      end
-
-      after do
-        travel_back
-      end
-
-      include_examples 'classified as', 'reverted'
     end
 
     context 'when district qualifier contradict' do
@@ -203,6 +181,25 @@ RSpec.describe StatementClassifier, type: :service do
       include_examples 'classified as', 'manually_actionable'
     end
 
+    context 'when statement is actionable, but has been actioned in the last 5 minutes' do
+      before do
+        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
+        travel_to supposed_current_time
+        # 3 minutes before that:
+        supposed_actioned_at_time = supposed_current_time - 3.0 / (24 * 60)
+        position_held.group = nil
+        allow(statement).to receive(:person_item).and_return('Q1')
+        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at?).and_return(true)
+      end
+
+      after do
+        travel_back
+      end
+
+      include_examples 'classified as', 'done'
+    end
+
     context 'when the statement has been actioned' do
       before do
         statement.verifications.build(status: true)
@@ -210,11 +207,6 @@ RSpec.describe StatementClassifier, type: :service do
       end
 
       include_examples 'classified as', 'done'
-    end
-
-    context 'when there are not any statements' do
-      let(:statement) { nil }
-      include_examples 'classified as', nil # not classified at all
     end
 
     context 'when the reconciled person has since been merged into someone else' do
@@ -239,22 +231,6 @@ RSpec.describe StatementClassifier, type: :service do
       end
 
       include_examples 'classified as', 'done'
-    end
-
-    context 'when the statements are reconciled but not verified' do
-      before do
-        allow(statement).to receive(:person_item).and_return('Q1')
-      end
-
-      include_examples 'classified as', 'verifiable'
-    end
-
-    context 'when the statement is from suggestions-store and is already correct (apart from the reference) in Wikidata' do
-      before do
-        allow(statement).to receive(:person_item).and_return('Q1')
-      end
-
-      include_examples 'classified as', 'verifiable'
     end
 
     context 'when the statement is not from suggestions-store and is already correct in Wikidata' do
@@ -388,6 +364,30 @@ RSpec.describe StatementClassifier, type: :service do
       end
 
       include_examples 'classified as', 'done'
+    end
+
+    context 'when statement would be actionable, but has been actioned over 5 minutes ago' do
+      before do
+        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
+        travel_to supposed_current_time
+        # 10 minutes before that:
+        supposed_actioned_at_time = supposed_current_time - 10.0 / (24 * 60)
+        position_held.group = nil
+        allow(statement).to receive(:person_item).and_return('Q1')
+        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at?).and_return(true)
+      end
+
+      after do
+        travel_back
+      end
+
+      include_examples 'classified as', 'reverted'
+    end
+
+    context 'when there are not any statements' do
+      let(:statement) { nil }
+      include_examples 'classified as', nil # not classified at all
     end
   end
 end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -182,19 +182,13 @@ RSpec.describe StatementClassifier, type: :service do
     end
 
     context 'when statement is actionable, but has been actioned in the last 5 minutes' do
+      around { |example| freeze_time { example.run } }
+
       before do
-        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
-        travel_to supposed_current_time
-        # 3 minutes before that:
-        supposed_actioned_at_time = supposed_current_time - 3.0 / (24 * 60)
         position_held.group = nil
         allow(statement).to receive(:person_item).and_return('Q1')
-        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at).and_return((5.minutes - 1.second).ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
-      end
-
-      after do
-        travel_back
       end
 
       include_examples 'classified as', 'done'
@@ -359,7 +353,6 @@ RSpec.describe StatementClassifier, type: :service do
 
       before do
         statement.verifications.build(status: true)
-        allow(statement).to receive(:actioned_at).and_return(Time.now - 10.minutes)
         allow(statement).to receive(:actioned_at?).and_return(true)
       end
 
@@ -367,19 +360,13 @@ RSpec.describe StatementClassifier, type: :service do
     end
 
     context 'when statement would be actionable, but has been actioned over 5 minutes ago' do
+      around { |example| freeze_time { example.run } }
+
       before do
-        supposed_current_time = DateTime.new(2018, 6, 6, 15, 1, 1)
-        travel_to supposed_current_time
-        # 10 minutes before that:
-        supposed_actioned_at_time = supposed_current_time - 10.0 / (24 * 60)
         position_held.group = nil
         allow(statement).to receive(:person_item).and_return('Q1')
-        allow(statement).to receive(:actioned_at).and_return(supposed_actioned_at_time)
+        allow(statement).to receive(:actioned_at).and_return(5.minutes.ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
-      end
-
-      after do
-        travel_back
       end
 
       include_examples 'classified as', 'reverted'


### PR DESCRIPTION
Fixes #316

If statement was in the `done` state and it is removed from the upstream source we now classify it as `removed`. And it is displayed as:

<img width="713" alt="screen shot 2018-09-11 at 15 15 51" src="https://user-images.githubusercontent.com/5426/45366738-09148e80-b5cf-11e8-9536-fc39a87f71e2.png">

Should we also display this message for statements in other states: `reverted`, `manually_actionable`?

