### PR TITLE
[#32] Use authenication for Suggestions Store requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The following environment variables will need to set and configured:
     WIKIDATA_SITE=test.wikidata.org OR www.wikidata.org
     WIKIDATA_USERNAME=...
     WIKIDATA_PASSWORD=...
-    SUGGESTIONS_STORE_URL=https://suggestions-store.mysociety.org/
-    ID_MAPPING_STORE_BASE_URL=https://id-mapping-store.mysociety.org/
+    SUGGESTIONS_STORE_URL=https://suggestions-store.mysociety.org
+    ID_MAPPING_STORE_BASE_URL=https://id-mapping-store.mysociety.org
     ID_MAPPING_STORE_API_KEY=...
     HOST_NAME=verification-pages.herokuapp.com
     FORCE_SSL=1

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatementsStatistics
-  def initialize(suggestion_store_url: 'https://suggestions-store.mysociety.org')
+  def initialize(suggestion_store_url: ENV['SUGGESTIONS_STORE_URL'])
     @suggestion_store_url = suggestion_store_url
   end
 

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class StatementsStatistics
-  def initialize(suggestion_store_url: ENV['SUGGESTIONS_STORE_URL'])
-    @suggestion_store_url = suggestion_store_url
-  end
-
   def statistics
-    countries.map do |country|
-      statements = JSON.parse(RestClient.get(country['export_json_url']))
+    SuggestionsStore.countries.map do |country|
+      statements = country.suggestions
       invalid_statements = statements.select { |s| s['position_item'].nil? }
       grouped_statements = (statements - invalid_statements).group_by { |s| s['position_item'] }
       position_stats = grouped_statements.map do |position, position_statements|
@@ -17,17 +13,11 @@ class StatementsStatistics
           existing_positions: existing_positions
         )
       end
-      [country['code'], [position_stats, invalid_statements]]
+      [country.code, [position_stats, invalid_statements]]
     end.to_h
   end
 
   private
-
-  attr_reader :suggestion_store_url
-
-  def countries
-    JSON.parse(RestClient.get(URI.join(suggestion_store_url, '/export/countries.json').to_s))
-  end
 
   def existing_positions
     return @position_to_page_titles if @position_to_page_titles

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,7 +14,7 @@ class Page < ApplicationRecord
   before_validation :set_parliamentary_term_name, if: :parliamentary_term_item_changed?
 
   def from_suggestions_store?
-    /^#{Regexp.escape(ENV.fetch('SUGGESTIONS_STORE_URL'))}/.match?(csv_source_url)
+    URI.parse(csv_source_url).host == URI.parse(SuggestionsStore::Request::URL).host
   end
 
   private

--- a/app/services/update_statement_verification.rb
+++ b/app/services/update_statement_verification.rb
@@ -9,11 +9,8 @@ class UpdateStatementVerification < ServiceBase
   end
 
   def run
-    uri = URI(ENV.fetch('SUGGESTIONS_STORE_URL'))
-    uri.path = "/suggestions/#{transaction_id}/verifications"
-    RestClient.post(uri.to_s, status: status)
-  rescue RestClient::Exception => e
-    raise "Suggestion store failed: #{e.message}"
+    SuggestionsStore::Suggestion.new(transaction_id: transaction_id)
+                                .verify!(status: status)
   end
 
   private

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -32,7 +32,7 @@
           missing (<%= link_to 'Create page', new_page_path(
             title: "User:Verification_pages_bot/verification/#{country_code.downcase}/",
             position_held_item: statement.position,
-            csv_source_url: "#{ENV['SUGGESTIONS_STORE_URL']}/export/#{country_code.downcase}/#{statement.position}.csv",
+            csv_source_url: SuggestionsStore::Country.new(code: country_code.downcase).export_position_url(position: statement.position, format: 'csv'),
             country_id: @country_lookup[country_code.downcase]
           ) %>)
         <% end %></td>

--- a/app/views/statements/statistics.html.erb
+++ b/app/views/statements/statistics.html.erb
@@ -32,7 +32,7 @@
           missing (<%= link_to 'Create page', new_page_path(
             title: "User:Verification_pages_bot/verification/#{country_code.downcase}/",
             position_held_item: statement.position,
-            csv_source_url: "#{ENV['SUGGESTIONS_STORE_URL']}export/#{country_code.downcase}/#{statement.position}.csv",
+            csv_source_url: "#{ENV['SUGGESTIONS_STORE_URL']}/export/#{country_code.downcase}/#{statement.position}.csv",
             country_id: @country_lookup[country_code.downcase]
           ) %>)
         <% end %></td>

--- a/config/initializers/suggestions_store.rb
+++ b/config/initializers/suggestions_store.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'suggestions_store'

--- a/lib/suggestions_store.rb
+++ b/lib/suggestions_store.rb
@@ -38,5 +38,9 @@ module SuggestionsStore
     end
   end
 
-  Suggestion = Class.new(OpenStruct)
+  class Suggestion < OpenStruct
+    def verify!(data = {})
+      Request.post("/suggestions/#{transaction_id}/verifications", data)
+    end
+  end
 end

--- a/lib/suggestions_store.rb
+++ b/lib/suggestions_store.rb
@@ -29,6 +29,10 @@ module SuggestionsStore
       URI.join(Request::URL, "/export/#{code}.#{format}").to_s
     end
 
+    def export_position_url(position:, format: 'json')
+      URI.join(Request::URL, "/export/#{code}/#{position}.#{format}").to_s
+    end
+
     private
 
     def get_suggestions(url)

--- a/lib/suggestions_store.rb
+++ b/lib/suggestions_store.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'suggestions_store/request'
+
+module SuggestionsStore
+  def self.countries
+    Request.get('/export/countries.json').map do |country_data|
+      Country.new(
+        code:            country_data[:code],
+        export_json_url: country_data[:export_json_url]
+      )
+    end
+  end
+
+  class Country
+    attr_reader :code, :export_json_url
+
+    def initialize(code:, export_json_url: nil)
+      @code = code
+      @export_json_url = export_json_url
+    end
+
+    def suggestions
+      url = export_json_url || export_url
+      get_suggestions(url)
+    end
+
+    def export_url(format: 'json')
+      URI.join(Request::URL, "/export/#{code}.#{format}").to_s
+    end
+
+    private
+
+    def get_suggestions(url)
+      Request.get(url).map do |suggestion_data|
+        Suggestion.new(suggestion_data)
+      end
+    end
+  end
+
+  Suggestion = Class.new(OpenStruct)
+end

--- a/lib/suggestions_store/request.rb
+++ b/lib/suggestions_store/request.rb
@@ -8,6 +8,8 @@ module SuggestionsStore
     URL = ENV.fetch(
       'SUGGESTIONS_STORE_URL', 'https://suggestions-store.mysociety.org'
     )
+    USERNAME = ENV['SUGGESTIONS_STORE_USERNAME']
+    PASSWORD = ENV['SUGGESTIONS_STORE_PASSWORD']
 
     def self.get(path)
       uri = URI.join(base_uri, path)
@@ -20,7 +22,10 @@ module SuggestionsStore
     end
 
     def self.base_uri
-      URI.parse(URL)
+      URI.parse(URL).tap do |uri|
+        uri.user = USERNAME
+        uri.password = PASSWORD
+      end
     end
     private_class_method :base_uri
 

--- a/lib/suggestions_store/request.rb
+++ b/lib/suggestions_store/request.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rest-client'
+
+module SuggestionsStore
+  class Request
+    URL = ENV.fetch(
+      'SUGGESTIONS_STORE_URL', 'https://suggestions-store.mysociety.org'
+    )
+
+    def self.get(path)
+      uri = URI.join(base_uri, path)
+      parse { RestClient.get(uri.to_s) }
+    end
+
+    def self.base_uri
+      URI.parse(URL)
+    end
+    private_class_method :base_uri
+
+    def self.parse(*)
+      response = yield
+      JSON.parse(response.body, symbolize_names: true)
+    rescue RestClient::Exception => e
+      raise "Suggestion store failed: #{e.message}"
+    end
+    private_class_method :parse
+  end
+end

--- a/lib/suggestions_store/request.rb
+++ b/lib/suggestions_store/request.rb
@@ -14,6 +14,11 @@ module SuggestionsStore
       parse { RestClient.get(uri.to_s) }
     end
 
+    def self.post(path, data)
+      uri = URI.join(base_uri, path)
+      parse { RestClient.post(uri.to_s, data) }
+    end
+
     def self.base_uri
       URI.parse(URL)
     end
@@ -21,7 +26,7 @@ module SuggestionsStore
 
     def self.parse(*)
       response = yield
-      JSON.parse(response.body, symbolize_names: true)
+      JSON.parse(response.body, symbolize_names: true) if response
     rescue RestClient::Exception => e
       raise "Suggestion store failed: #{e.message}"
     end

--- a/lib/tasks/add_csv_source_url_to_pages.rake
+++ b/lib/tasks/add_csv_source_url_to_pages.rake
@@ -4,9 +4,9 @@ desc 'Add CSV source URL to existing pages'
 task add_csv_source_url_to_pages: :environment do
   Page.transaction do
     Page.find_each do |page|
-      uri = URI(ENV.fetch('SUGGESTIONS_STORE_URL'))
-      uri.path = "/export/#{page.country.code}/#{page.position_held_item}.csv"
-      page.csv_source_url = uri.to_s
+      country = SuggestionsStore::Country.new(page.country.code)
+      url = country.export_position_url(page.position_held_item, format: 'csv')
+      page.csv_source_url = url
       page.save!
     end
   end

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -7,8 +7,9 @@ describe StatementsStatistics do
     let! (:page) { create(:page, position_held_item: 'Q15964890') }
 
     before do
-      stub_request(:get, 'https://suggestions-store.mysociety.org/export/countries.json')
-        .to_return(body: '[{"code": "ca", "export_json_url": "https://suggestions-store.mysociety.org/export/ca.json"}]')
+      ENV['SUGGESTIONS_STORE_URL'] = 'http://suggestions-store'
+      stub_request(:get, 'http://suggestions-store/export/countries.json')
+        .to_return(body: '[{"code": "ca", "export_json_url": "http://suggestions-store/export/ca.json"}]')
       body = [
         {
           id:                  1,
@@ -30,7 +31,7 @@ describe StatementsStatistics do
           verification_status: 'invalid',
         },
       ]
-      stub_request(:get, 'https://suggestions-store.mysociety.org/export/ca.json')
+      stub_request(:get, 'http://suggestions-store/export/ca.json')
         .to_return(body: JSON.generate(body))
     end
 

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -7,7 +7,7 @@ describe StatementsStatistics do
     let! (:page) { create(:page, position_held_item: 'Q15964890') }
 
     before do
-      ENV['SUGGESTIONS_STORE_URL'] = 'http://suggestions-store'
+      stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
       stub_request(:get, 'http://suggestions-store/export/countries.json')
         .to_return(body: '[{"code": "ca", "export_json_url": "http://suggestions-store/export/ca.json"}]')
       body = [

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -70,8 +70,12 @@ RSpec.describe Page, type: :model do
   end
 
   describe '#from_suggestions_store?' do
+    before do
+      ENV['SUGGESTIONS_STORE_URL'] = 'http://suggestions-store'
+    end
+
     it 'knows that it came from suggestions-store' do
-      page = create(:page, csv_source_url: "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/blah.csv")
+      page = create(:page, csv_source_url: "http://suggestions-store/export/blah.csv")
       expect(page.from_suggestions_store?).to eq(true)
     end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -71,16 +71,16 @@ RSpec.describe Page, type: :model do
 
   describe '#from_suggestions_store?' do
     before do
-      ENV['SUGGESTIONS_STORE_URL'] = 'http://suggestions-store'
+      stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
     end
 
     it 'knows that it came from suggestions-store' do
-      page = create(:page, csv_source_url: "http://suggestions-store/export/blah.csv")
+      page = create(:page, csv_source_url: 'http://suggestions-store/export/blah.csv')
       expect(page.from_suggestions_store?).to eq(true)
     end
 
     it 'know that it didn\'t come from suggestions-store' do
-      page = create(:page)
+      page = create(:page, csv_source_url: 'http://example.com')
       expect(page.from_suggestions_store?).to eq(false)
     end
   end

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -51,14 +51,18 @@ RSpec.describe Statement, type: :model do
   end
 
   describe '#from_suggestions_store?' do
+    before do
+      stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
+    end
+
     it 'knows that it came from suggestions-store' do
-      page = create(:page, csv_source_url: "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/blah.csv")
+      page = create(:page, csv_source_url: 'http://suggestions-store/export/blah.csv')
       statement = create(:statement, page: page)
       expect(statement.from_suggestions_store?).to eq(true)
     end
 
     it 'know that it didn\'t come from suggestions-store' do
-      page = create(:page)
+      page = create(:page, csv_source_url: 'http://example.com')
       statement = create(:statement, page: page)
       expect(statement.from_suggestions_store?).to eq(false)
     end

--- a/spec/models/verification_spec.rb
+++ b/spec/models/verification_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Verification, type: :model do
   end
 
   describe 'after commit callback' do
+    before do
+      stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
+    end
+
     context 'the page is from suggestions-store' do
       it 'sends verification to suggestions-store' do
         expect(UpdateStatementVerification).to receive(:run)
@@ -19,7 +23,7 @@ RSpec.describe Verification, type: :model do
 
         page = build(
           :page,
-          csv_source_url: "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/blah.csv"
+          csv_source_url: 'http://suggestions-store/export/blah.csv'
         )
         verification.statement = build(:statement, page: page)
         verification.user = 'Bilbo'
@@ -38,7 +42,11 @@ RSpec.describe Verification, type: :model do
       it 'should not send verification to suggestions-store' do
         expect(UpdateStatementVerification).to_not receive(:run)
 
-        verification.statement = build(:statement)
+        page = build(
+          :page,
+          csv_source_url: 'http://example.com'
+        )
+        verification.statement = build(:statement, page: page)
         verification.user = 'Bilbo'
         verification.reference_url = 'https://example.org/members/'
         verification.save! # create

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe StatementClassifier, type: :service do
     build(
       :page,
       parliamentary_term_item: 'Q2',
-      csv_source_url:          "#{ENV.fetch('SUGGESTIONS_STORE_URL')}/export/ca.csv"
+      csv_source_url:          'http://suggestions-store/export/ca.csv'
     )
   end
 
@@ -25,6 +25,7 @@ RSpec.describe StatementClassifier, type: :service do
   let(:classifier) { StatementClassifier.new('page_title') }
 
   before do
+    stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
     allow(statement_relation).to receive_message_chain(
       :original, :includes, :references, :order
     ).and_return(statement_relation)

--- a/spec/services/update_statement_verification_spec.rb
+++ b/spec/services/update_statement_verification_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe UpdateStatementVerification, type: :service do
   end
 
   describe 'running update' do
-    before { ENV['SUGGESTIONS_STORE_URL'] = 'http://example.com/' }
+    before do
+      stub_const('SuggestionsStore::Request::URL', 'http://example.com/')
+    end
 
     context 'verified' do
       let(:status) { true }


### PR DESCRIPTION
Fixes #32 
Requires to https://github.com/mysociety/suggestions-store/pull/21

This extracts out requests to Suggestions Store into a common interface and adds the ability to use HTTP authentication.

Should consider rewriting existing specs to stub the new interface rather than the HTTP requests.