### PR TITLE
Copy reference URL for duplicate verifications

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -67,8 +67,9 @@ class Statement < ApplicationRecord
     return unless duplicate_verification
 
     verifications.create!(
-      user:   duplicate_verification.user,
-      status: duplicate_verification.status
+      user:          duplicate_verification.user,
+      status:        duplicate_verification.status,
+      reference_url: duplicate_verification.reference_url
     )
   end
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -173,4 +173,26 @@ RSpec.describe Statement, type: :model do
       is_expected.to_not include(other)
     end
   end
+
+  describe '#verify_duplicates! after_create callback' do
+    let(:page) { build(:page) }
+
+    let(:attributes) { attributes_for(:statement_with_names) }
+
+    let!(:statement) do
+      create(:statement, attributes.merge(transaction_id: '123', page: page))
+    end
+
+    before do
+      statement.verifications.create!(
+        reference_url: 'http://example.com/members/',
+        user:          'TestUser'
+      )
+    end
+
+    it 'creates verifications for the duplicate' do
+      new_duplicate = create(:statement, attributes.merge(transaction_id: '456', page: page))
+      expect(new_duplicate.verifications.size).to be(1)
+    end
+  end
 end


### PR DESCRIPTION
We recently added a required `reference_url` field to the `Verification` model, but forgot to update this bit of code to copy the reference URL over when creating duplicate verifications.

Fixes #419 