### PR TITLE
[#446] Configure ActionMailer to use Exim in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,12 +72,15 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "verification_pages_#{Rails.env}"
 
-  config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.sendmail_settings = {
+    location:  '/usr/sbin/exim4',
+    arguments: '-i',
+  }
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to
-  # raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Fixes #446 

We missed the ActionMailer configuration when merging #457. I have tested this from the Rails console resulting in: https://groups.google.com/a/mysociety.org/forum/#!topic/cron-verification-pages/OO8-SA4FDj4