### PR TITLE
Only show suggestions-store pages on statistics page

### DIFF
--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -23,7 +23,7 @@ class StatementsStatistics
     return @position_to_page_titles if @position_to_page_titles
     # Make a Hash mapping from a position to a Set of associated page titles:
     @position_to_page_titles = Hash.new { |h, k| h[k] = Set.new }
-    Page.pluck(:position_held_item, :title).each_with_object(@position_to_page_titles) do |(position, page_title), acc|
+    Page.select(&:from_suggestions_store?).pluck(:position_held_item, :title).each_with_object(@position_to_page_titles) do |(position, page_title), acc|
       acc[position].add(page_title)
     end
   end

--- a/spec/lib/statements_statistics_spec.rb
+++ b/spec/lib/statements_statistics_spec.rb
@@ -4,7 +4,21 @@ require 'rails_helper'
 
 describe StatementsStatistics do
   describe '#statistics' do
-    let! (:page) { create(:page, position_held_item: 'Q15964890') }
+    let! (:page) do
+      create(
+        :page,
+        position_held_item: 'Q15964890',
+        csv_source_url:     'http://suggestions-store/export/ca.csv'
+      )
+    end
+
+    let! (:non_suggestions_store_page) do
+      create(
+        :page,
+        position_held_item: 'Q15964890',
+        csv_source_url:     'http://example.com/ca.csv'
+      )
+    end
 
     before do
       stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
@@ -48,7 +62,15 @@ describe StatementsStatistics do
       expect(position_stats.correct).to eq(2)
       expect(position_stats.incorrect).to eq(1)
       expect(position_stats.unchecked).to eq(0)
-      expect(position_stats.pages).to eq([page.title])
+    end
+
+    it 'only shows suggestions-store pages' do
+      statement_statistics = StatementsStatistics.new
+      statistics = statement_statistics.statistics['ca']
+      position_stats = statistics.first.first
+      expect(position_stats.pages.size).to eq(1)
+      expect(position_stats.pages).to include(page.title)
+      expect(position_stats.pages).to_not include(non_suggestions_store_page.title)
     end
   end
 end


### PR DESCRIPTION
The current statistics page is intended to be just about pages created from the suggestions-store data, but we were showing pages that were created from other sources.

This change adds an extra check to ensure we only display pages based on suggestions-store data on the statistics page.

Fixes #433 