### PR TITLE
[#380] Improve transaction ID hashes

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,8 @@
 
 # Verification page object
 class Page < ApplicationRecord
+  include TransactionID
+
   has_many :statements, dependent: :destroy
   belongs_to :country
 

--- a/app/models/page/transaction_id.rb
+++ b/app/models/page/transaction_id.rb
@@ -2,10 +2,26 @@
 
 class Page
   module TransactionID
-    def generate_transaction_id(data)
-      pairs = data.merge(country: country.code).sort
+    UnknownHashEpochError = Class.new(StandardError)
 
-      transation_string = pairs.each_with_object([]) do |(k, v), a|
+    def generate_transaction_id(data)
+      hash(data.merge(hash_data))
+    end
+
+    private
+
+    def hash_data
+      # These hashes should not be modified. it will change existing transaction
+      # IDs resulting in duplicate Statements being created when page CSV
+      # sources are next fetched
+      case hash_epoch
+      when 1 then { country: country.code }
+      else raise UnknownHashEpochError
+      end
+    end
+
+    def hash(pairs)
+      transation_string = pairs.sort.each_with_object([]) do |(k, v), a|
         a << "#{k}:#{v}"
       end.join(';')
 

--- a/app/models/page/transaction_id.rb
+++ b/app/models/page/transaction_id.rb
@@ -16,6 +16,7 @@ class Page
       # sources are next fetched
       case hash_epoch
       when 1 then { country: country.code }
+      when 2 then { country: country.code, page: id }
       else raise UnknownHashEpochError
       end
     end

--- a/app/models/page/transaction_id.rb
+++ b/app/models/page/transaction_id.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Page
+  module TransactionID
+    def generate_transaction_id(data)
+      pairs = data.merge(country: country.code).sort
+
+      transation_string = pairs.each_with_object([]) do |(k, v), a|
+        a << "#{k}:#{v}"
+      end.join(';')
+
+      'md5:' + Digest::MD5.hexdigest(transation_string)
+    end
+  end
+end

--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -19,7 +19,7 @@ class LoadStatements < ServiceBase
   private
 
   def parse_result(result)
-    result[:transaction_id] ||= generate_transaction_id(result)
+    result[:transaction_id] ||= page.generate_transaction_id(result.to_h)
 
     statement = page.statements.find_or_initialize_by(
       transaction_id: result[:transaction_id]
@@ -61,15 +61,5 @@ class LoadStatements < ServiceBase
     RestClient.get(page.csv_source_url).body
   rescue RestClient::Exception => e
     raise "Suggestion store failed: #{e.message}"
-  end
-
-  def generate_transaction_id(result)
-    pairs = result.to_h.merge(country: page.country.code).sort
-
-    transation_string = pairs.each_with_object([]) do |(k, v), a|
-      a << "#{k}:#{v}"
-    end.join(';')
-
-    'md5:' + Digest::MD5.hexdigest(transation_string)
   end
 end

--- a/db/migrate/20180924100323_add_hash_epoch_to_pages.rb
+++ b/db/migrate/20180924100323_add_hash_epoch_to_pages.rb
@@ -1,0 +1,5 @@
+class AddHashEpochToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :hash_epoch, :integer, default: 1
+  end
+end

--- a/db/migrate/20180924102808_increase_page_has_epoch.rb
+++ b/db/migrate/20180924102808_increase_page_has_epoch.rb
@@ -1,0 +1,9 @@
+class IncreasePageHasEpoch < ActiveRecord::Migration[5.2]
+  def up
+    change_column :pages, :hash_epoch, :integer, default: 2
+  end
+
+  def down
+    change_column :pages, :hash_epoch, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_100323) do
+ActiveRecord::Schema.define(version: 2018_09_24_102808) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_100323) do
     t.string "reference_url_language"
     t.string "position_held_name"
     t.string "parliamentary_term_name"
-    t.integer "hash_epoch", default: 1
+    t.integer "hash_epoch", default: 2
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_111831) do
+ActiveRecord::Schema.define(version: 2018_09_24_100323) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2018_09_13_111831) do
     t.string "reference_url_language"
     t.string "position_held_name"
     t.string "parliamentary_term_name"
+    t.integer "hash_epoch", default: 1
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/models/page/transaction_id_spec.rb
+++ b/spec/models/page/transaction_id_spec.rb
@@ -27,5 +27,16 @@ RSpec.describe Page::TransactionID, type: :model do
         is_expected.to eq 'md5:abc'
       end
     end
+
+    context 'with hash_epoch = 2' do
+      before { page.hash_epoch = 2 }
+
+      it 'should merge the country code and page ID then MD5 stored hash data string' do
+        page.id = 1
+        data_string = 'bar:bar;country:ca;foo:foo;page:1'
+        expect(Digest::MD5).to receive(:hexdigest).with(data_string) { 'def' }
+        is_expected.to eq 'md5:def'
+      end
+    end
   end
 end

--- a/spec/models/page/transaction_id_spec.rb
+++ b/spec/models/page/transaction_id_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::TransactionID, type: :model do
+  let(:page) { build(:page) }
+
+  describe '#generate_transaction_id' do
+    subject { page.generate_transaction_id(data) }
+
+    let(:data) { { foo: 'foo', bar: 'bar' } }
+
+    it 'should merge the country code then MD5 stored hash data string' do
+      data_string = 'bar:bar;country:ca;foo:foo'
+      expect(Digest::MD5).to receive(:hexdigest).with(data_string) { 'abc' }
+      is_expected.to eq 'md5:abc'
+    end
+  end
+end

--- a/spec/models/page/transaction_id_spec.rb
+++ b/spec/models/page/transaction_id_spec.rb
@@ -10,10 +10,22 @@ RSpec.describe Page::TransactionID, type: :model do
 
     let(:data) { { foo: 'foo', bar: 'bar' } }
 
-    it 'should merge the country code then MD5 stored hash data string' do
-      data_string = 'bar:bar;country:ca;foo:foo'
-      expect(Digest::MD5).to receive(:hexdigest).with(data_string) { 'abc' }
-      is_expected.to eq 'md5:abc'
+    context 'with hash_epoch = nil' do
+      before { page.hash_epoch = nil }
+
+      it 'should raise unknown hash epoch error' do
+        expect { subject }.to raise_error 'Page::TransactionID::UnknownHashEpochError'
+      end
+    end
+
+    context 'with hash_epoch = 1' do
+      before { page.hash_epoch = 1 }
+
+      it 'should merge the country code then MD5 stored hash data string' do
+        data_string = 'bar:bar;country:ca;foo:foo'
+        expect(Digest::MD5).to receive(:hexdigest).with(data_string) { 'abc' }
+        is_expected.to eq 'md5:abc'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #380 

This adds the Page ID to the transaction ID hashes but keeps the original functionality for existing pages so statements aren't duplicated next time page CSV source is fetched.

Any future changes to these hash can be done by increment of the `Page#hash_epoch` value again.