### PR TITLE
Allow pages to be archived

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -80,7 +80,8 @@ class PagesController < ApplicationController
                                  :parliamentary_term_item, :reference_url,
                                  :country_id,
                                  :csv_source_url, :executive_position,
-                                 :reference_url_title, :reference_url_language)
+                                 :reference_url_title, :reference_url_language,
+                                 :archived)
   end
 
   def new_page_params

--- a/app/lib/statements_statistics.rb
+++ b/app/lib/statements_statistics.rb
@@ -23,7 +23,7 @@ class StatementsStatistics
     return @position_to_page_titles if @position_to_page_titles
     # Make a Hash mapping from a position to a Set of associated page titles:
     @position_to_page_titles = Hash.new { |h, k| h[k] = Set.new }
-    Page.select(&:from_suggestions_store?).pluck(:position_held_item, :title).each_with_object(@position_to_page_titles) do |(position, page_title), acc|
+    Page.where(archived: false).select(&:from_suggestions_store?).pluck(:position_held_item, :title).each_with_object(@position_to_page_titles) do |(position, page_title), acc|
       acc[position].add(page_title)
     end
   end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -78,6 +78,11 @@
     <%= f.label :executive_position, class: 'form-check-label' %>
     <%= f.error_span(:executive_position) %>
   </div>
+  <div class="form-check">
+    <%= f.check_box :archived %>
+    <%= f.label :archived, class: 'form-check-label' %>
+    <%= f.error_span(:archived) %>
+  </div>
 
   <div class="form-group">
     <div class="col-lg-offset-2 col-lg-10">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -4,7 +4,7 @@
 </div>
 
 <% if flash[:notice] %>
-  <p class="flash flash-notice"><%= flash[:notice] %></p>
+  <p class="alert alert-success"><%= flash[:notice] %></p>
 <% end %>
 
 <dl class="dl-horizontal">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -3,6 +3,10 @@
   <h1><%= t '.title', default: model_class.model_name.human.titleize %></h1>
 </div>
 
+<% if @page.archived? %>
+  <p class="alert alert-warning">This page has been archived.</p>
+<% end %>
+
 <% if flash[:notice] %>
   <p class="alert alert-success"><%= flash[:notice] %></p>
 <% end %>
@@ -28,6 +32,8 @@
   <dd><%= link_to @page.country.name, @page.country %></dd>
   <dt><strong><%= model_class.human_attribute_name(:executive_position) %>:</strong></dt>
   <dd><%= @page.executive_position %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:archived) %>:</strong></dt>
+  <dd><%= @page.archived %></dd>
   <dt><strong>Statements</strong></dt>
   <dd><%= @page.statements.count %></dd>
 </dl>

--- a/db/migrate/20181024075747_add_archived_to_pages.rb
+++ b/db/migrate/20181024075747_add_archived_to_pages.rb
@@ -1,0 +1,5 @@
+class AddArchivedToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :archived, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_24_102808) do
+ActiveRecord::Schema.define(version: 2018_10_24_075747) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2018_09_24_102808) do
     t.string "position_held_name"
     t.string "parliamentary_term_name"
     t.integer "hash_epoch", default: 2
+    t.boolean "archived", default: false, null: false
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 


### PR DESCRIPTION
This adds an `archived` column to the `pages` table. Archived pages won't appear on the statistics page, which means there will instead be a link to create a new page.

Fixes https://github.com/mysociety/verification-pages/issues/490