### PR TITLE
Ignore districts for executive position

### DIFF
--- a/app/services/new_statement_classifier.rb
+++ b/app/services/new_statement_classifier.rb
@@ -160,7 +160,7 @@ class NewStatementClassifier
     {
       position: { id: page.position_held_item },
       term:     {
-        id:    page.parliamentary_term_item,
+        id:    page.parliamentary_term_item.presence,
         start: parliamentary_term_data.start,
         end:   parliamentary_term_data.end,
       },

--- a/app/services/new_statement_classifier.rb
+++ b/app/services/new_statement_classifier.rb
@@ -165,7 +165,7 @@ class NewStatementClassifier
         end:   parliamentary_term_data.end,
       },
       party:    { id: statement.parliamentary_group_item },
-      district: { id: statement.electoral_district_item },
+      district: { id: !page.executive_position? ? statement.electoral_district_item : nil },
       start:    statement.position_start,
       end:      statement.position_end,
     }


### PR DESCRIPTION
Identify issues with executive position pages (EG User:Verification_pages_bot/verification/ca/Mayor_of_Ottawa) which stop the membership comparison gem from detecting the exact match and classifying the statement as reverted.

