### PR TITLE
Record classifier version

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -22,7 +22,7 @@ class StatementsController < FrontendController
 
     case params[:force_type]
     when 'done'
-      statement.record_actioned!
+      statement.record_actioned!(params[:classifier])
     when 'manually_actionable'
       statement.report_error!(params[:error_message])
     when 'actionable'

--- a/app/decorators/new_statement_decorator.rb
+++ b/app/decorators/new_statement_decorator.rb
@@ -41,7 +41,7 @@ class NewStatementDecorator < SimpleDelegator
 
   def recently_actioned?
     # Was this statement actioned in the last 5 minutes?
-    return false unless actioned_at?
+    return false unless actioned?
     time_difference_seconds = Time.zone.now - actioned_at
     (time_difference_seconds / 60.0) < 5
   end
@@ -53,7 +53,7 @@ class NewStatementDecorator < SimpleDelegator
   end
 
   def reverted?
-    !done? && actioned_at? && statement_uuid
+    !done? && actioned? && statement_uuid
   end
 
   def done_or_reverted?
@@ -91,7 +91,7 @@ class NewStatementDecorator < SimpleDelegator
   end
 
   def actioned_but_no_statement_problem
-    return [] unless actioned_at? && !statement_uuid
+    return [] unless actioned? && !statement_uuid
     ["There were no 'position held' (P39) statements on Wikidata that match the actioned suggestion"]
   end
 
@@ -120,5 +120,9 @@ class NewStatementDecorator < SimpleDelegator
 
   def verified_on
     latest_verification.try(:created_at).try(:to_date)
+  end
+
+  def actioned?
+    actioned_at? && classifier_version == 2
   end
 end

--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -23,8 +23,9 @@ class Statement < ApplicationRecord
     reconciliations.last
   end
 
-  def record_actioned!
+  def record_actioned!(classifier_version = nil)
     self.actioned_at = Time.zone.now
+    self.classifier_version = classifier_version.sub(/^v/, '') if classifier_version
     save!
   end
 

--- a/db/migrate/20181025094234_add_classifier_version_to_statements.rb
+++ b/db/migrate/20181025094234_add_classifier_version_to_statements.rb
@@ -1,0 +1,5 @@
+class AddClassifierVersionToStatements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :statements, :classifier_version, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_24_075747) do
+ActiveRecord::Schema.define(version: 2018_10_25_094234) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_075747) do
     t.date "position_start"
     t.date "position_end"
     t.boolean "removed_from_source", default: false
+    t.integer "classifier_version", default: 1
     t.index ["page_id"], name: "index_statements_on_page_id"
   end
 

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe Statement, type: :model do
         change(statement, :actioned_at).from(nil).to(Time.zone.now)
       )
     end
+
+    it 'assigns classifier_version' do
+      expect { statement.record_actioned!('v2') }.to(
+        change(statement, :classifier_version).from(1).to(2)
+      )
+    end
   end
 
   describe '#report_error!' do

--- a/spec/services/new_statement_classifier_spec.rb
+++ b/spec/services/new_statement_classifier_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe NewStatementClassifier, type: :service do
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return(5.minutes.ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
+        allow(statement).to receive(:classifier_version).and_return(2)
       end
 
       include_examples 'classified as', 'manually_actionable'
@@ -195,6 +196,7 @@ RSpec.describe NewStatementClassifier, type: :service do
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return((5.minutes - 1.second).ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
+        allow(statement).to receive(:classifier_version).and_return(2)
       end
 
       include_examples 'classified as', 'done'
@@ -390,6 +392,7 @@ RSpec.describe NewStatementClassifier, type: :service do
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return(5.minutes.ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
+        allow(statement).to receive(:classifier_version).and_return(2)
       end
 
       include_examples 'classified as', 'reverted'
@@ -416,6 +419,7 @@ RSpec.describe NewStatementClassifier, type: :service do
         allow(statement).to receive(:person_item).and_return('Q1')
         allow(statement).to receive(:actioned_at).and_return(5.minutes.ago)
         allow(statement).to receive(:actioned_at?).and_return(true)
+        allow(statement).to receive(:classifier_version).and_return(2)
       end
 
       include_examples 'classified as', 'removed'


### PR DESCRIPTION
Add classifier version to statements

This will store what version of the classifier was used to action a statement.

It will allow statements which have ended up in the reverted while using the old classifier to be actionable again if the new classifier is being used. 