### PR TITLE
[#521] Switch to the new classifier by default

### DIFF
--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -25,10 +25,10 @@ class FrontendController < ApplicationController
 
   def classifier_klass
     case params[:classifier]
-    when 'v2'
-      NewStatementClassifier
-    else
+    when 'v1'
       StatementClassifier
+    else
+      NewStatementClassifier
     end
   end
 end

--- a/spec/controllers/reconciliations_controller_spec.rb
+++ b/spec/controllers/reconciliations_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ReconciliationsController, type: :controller do
         before do
           allow(Statement).to receive(:find_by!).and_return(statement)
           allow(statement).to receive(:reconciliations).and_return(relation)
-          allow(StatementClassifier).to receive(:new).and_return(classifier)
+          allow(NewStatementClassifier).to receive(:new).and_return(classifier)
         end
 
         it 'finds statement and creates reconciliation' do
@@ -53,7 +53,7 @@ RSpec.describe ReconciliationsController, type: :controller do
         before do
           allow(Statement).to receive(:find_by!).and_return(statement)
           allow(statement).to receive(:reconciliations).and_return(relation)
-          allow(StatementClassifier).to receive(:new).and_return(classifier)
+          allow(NewStatementClassifier).to receive(:new).and_return(classifier)
         end
 
         it 'finds statement and creates reconciliation' do

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe VerificationsController, type: :controller do
     before do
       allow(Statement).to receive(:find_by!).and_return(statement)
       allow(statement).to receive(:verifications).and_return(relation)
-      allow(StatementClassifier).to receive(:new).and_return(classifier)
+      allow(NewStatementClassifier).to receive(:new).and_return(classifier)
     end
 
     it 'finds statement and creates verification' do


### PR DESCRIPTION
Fixes #521 

Leaving the v1 classifier for now until we're ready to remove the code.
