### PR TITLE
Lock node version on Travis to 8.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - gem update --system
   - cp config/database.yml.sample config/database.yml
   - . $HOME/.nvm/nvm.sh
-  - nvm install --lts
-  - nvm use --lts
+  - nvm install 8.11
+  - nvm use 8.11
 install:
   - bundle install --jobs=3 --retry=3
   - yarn install


### PR DESCRIPTION
There has been a new LTS version (10.13.x) which some packages aren't
compatible with yet. Toolforge also is using 8.11.x.