### PR TITLE
[#499] Fix statement updating hanging after actioning

### DIFF
--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -118,7 +118,7 @@ export default template({
         that.$parent.$emit('statement-update', () => {
           return Axios.get(
             ENV.url + '/statements/' + that.statement.transaction_id + '.json',
-            { params: { force_type: 'done', classifier: this.$parent.classifierVersion } }
+            { params: { force_type: 'done', classifier: that.$parent.classifierVersion } }
           )
         })
       }).catch(function (error) {


### PR DESCRIPTION
Fixes #499 

Within the wikiapi client can return promises which don't have the same
scope as outside so we need to use `that` instead of `this`.