### PR TITLE
[#521] Switch to new classifier redux

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,10 +14,7 @@ class PagesController < ApplicationController
 
   # GET /pages/1
   def show
-    @query = RetrievePositionData.new(
-      @page.position_held_item,
-      @page.parliamentary_term_item
-    ).query
+    @query = NewRetrievePositionData.new(@page.position_held_item).query
   end
 
   # GET /pages/new

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -22,7 +22,7 @@ class StatementsController < FrontendController
 
     case params[:force_type]
     when 'done'
-      statement.record_actioned!(params[:classifier])
+      statement.record_actioned!(classifier_klass::VERSION)
     when 'manually_actionable'
       statement.report_error!(params[:error_message])
     when 'actionable'

--- a/app/services/generate_verification_page.rb
+++ b/app/services/generate_verification_page.rb
@@ -17,7 +17,7 @@ class GenerateVerificationPage < ServiceBase
   private
 
   def classified_statements
-    @classified_statements ||= StatementClassifier.new(page.title)
+    @classified_statements ||= NewStatementClassifier.new(page.title)
   end
 
   def template

--- a/app/services/new_statement_classifier.rb
+++ b/app/services/new_statement_classifier.rb
@@ -6,6 +6,8 @@ require 'membership_comparison'
 class NewStatementClassifier
   attr_reader :page, :statements, :transaction_id
 
+  VERSION = 'v2'
+
   def initialize(page_title, transaction_ids: [])
     @page = Page.find_by!(title: page_title)
     @statements = page.statements.original

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -4,6 +4,8 @@
 class StatementClassifier
   attr_reader :page, :statements, :transaction_id
 
+  VERSION = 'v1'
+
   def initialize(page_title, transaction_ids: [])
     @page = Page.find_by!(title: page_title)
     @statements = page.statements.original

--- a/spec/services/generate_verification_page_spec.rb
+++ b/spec/services/generate_verification_page_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe GenerateVerificationPage, type: :service do
   describe '#run' do
     it 'calls render with page and classified statements' do
       position_held_data = double(:position_held_data)
-      allow(RetrievePositionData).to receive(:run)
+      allow(NewRetrievePositionData).to receive(:run)
         .with(page.position_held_item)
         .and_return(position_held_data)
 
       classified_statements = double(:classified_statements)
-      expect(StatementClassifier).to receive(:new)
+      expect(NewStatementClassifier).to receive(:new)
         .with('page_title')
         .and_return(classified_statements)
 


### PR DESCRIPTION
Connects to #521 

- Use new classifier when generating verification wiki pages
- Use new classifier query for the 'Find current positions from Wikidata' link on `admin/pages#show`
- Ensure the classifier version is saved when actioning as this might not be coming in via the params now - otherwise we could get prompted to action a statement more than once.