### PR TITLE
[#536]  Prevent statements from going missing if updated in source CSV

### DIFF
--- a/app/models/statement.rb
+++ b/app/models/statement.rb
@@ -47,7 +47,8 @@ class Statement < ApplicationRecord
       person_name:             person_name,
       electoral_district_name: electoral_district_name,
       electoral_district_item: electoral_district_item,
-      fb_identifier:           fb_identifier
+      fb_identifier:           fb_identifier,
+      removed_from_source:     false
     )
   end
 

--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -11,10 +11,12 @@ class LoadStatements < ServiceBase
   end
 
   def run
-    touched_statements = csv.map { |result| parse_result(result) }
-    untouched_statements = page.statements.where.not(id: touched_statements)
-    untouched_statements.update(removed_from_source: true)
-    touched_statements
+    Statement.transaction do
+      touched_statements = csv.map { |result| parse_result(result) }
+      untouched_statements = page.statements.where.not(id: touched_statements)
+      untouched_statements.update(removed_from_source: true)
+      touched_statements
+    end
   end
 
   private

--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -15,6 +15,7 @@ class LoadStatements < ServiceBase
       touched_statements = csv.map { |result| parse_result(result) }
       untouched_statements = page.statements.where.not(id: touched_statements)
       untouched_statements.update(removed_from_source: true)
+      touched_statements.each(&:save!)
       touched_statements
     end
   end
@@ -41,7 +42,7 @@ class LoadStatements < ServiceBase
     end
 
     # The other attributes we always update from the upstream CSV:
-    statement.update!(
+    statement.assign_attributes(
       page:                     page,
       person_name:              result[:person_name],
       electoral_district_name:  result[:electoral_district_name],

--- a/spec/models/statement_spec.rb
+++ b/spec/models/statement_spec.rb
@@ -136,6 +136,10 @@ RSpec.describe Statement, type: :model do
       create(:statement, attributes.merge(transaction_id: '789', page: page_2))
     end
 
+    let!(:removed) do
+      create(:statement, attributes.merge(transaction_id: 'ABC', page: page, removed_from_source: true))
+    end
+
     subject { statement.self_and_duplicate_statements }
 
     it 'returns self' do
@@ -148,6 +152,10 @@ RSpec.describe Statement, type: :model do
 
     it 'does not returns statements from other pages' do
       is_expected.to_not include(other)
+    end
+
+    it 'does not returns statements removed from source' do
+      is_expected.to_not include(removed)
     end
   end
 

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -207,5 +207,31 @@ RSpec.describe LoadStatements do
         expect(result).to match_array([new_statement])
       end
     end
+
+    context 'items have been updated in upstream source' do
+      let(:suggestions_store_response) do
+        <<~CSV
+          person_name,person_item
+          Alice,Q1234
+        CSV
+      end
+
+      let!(:existing) { create(:statement, person_name: 'Alice', page: page) }
+      let(:statement) { Statement.last }
+
+      before do
+        load_statements = LoadStatements.new(page.title)
+        expect { load_statements.run }.to change(Statement, :count).by(1)
+      end
+
+      it 'should replace existing statement' do
+        existing.reload
+        expect(existing).to be_removed_from_source
+      end
+
+      it 'should not mark new statement as a duplicate' do
+        expect(statement).to_not be_duplicate
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #536 
