### PR TITLE
[#534] Add column name aliases for CSV statement loading

### DIFF
--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -47,6 +47,38 @@ class Row < OpenStruct
     super || page.generate_transaction_id(data)
   end
 
+  def electoral_district_name
+    super || area || constituency || district
+  end
+
+  def electoral_district_item
+    super || area_id || constituency_id || district_id
+  end
+
+  def parliamentary_group_name
+    super || alliance || coalition || faction || party || group
+  end
+
+  def parliamentary_group_item
+    super || alliance_id || coalition_id || faction_id || party_id || group_id
+  end
+
+  def person_name
+    super || name
+  end
+
+  def person_item
+    super || id || wikidata
+  end
+
+  def position_start
+    super || start_date
+  end
+
+  def position_end
+    super || start_end
+  end
+
   def parse
     # We need to be careful not wipe out any manually reconciled
     # items when refreshing from the upstream CSV file, so don't
@@ -81,5 +113,37 @@ class Row < OpenStruct
     @statement ||= page.statements.find_or_initialize_by(
       transaction_id: transaction_id
     )
+  end
+
+  def area_id
+    super || area_wikidata || wikidata_area
+  end
+
+  def constituency_id
+    super || constituency_wikidata || wikidata_constituency
+  end
+
+  def district_id
+    super || district_wikidata || wikidata_district
+  end
+
+  def alliance_id
+    super || alliance_wikidata || wikidata_alliance
+  end
+
+  def coalition_id
+    super || coalition_wikidata || wikidata_coalition
+  end
+
+  def faction_id
+    super || faction_wikidata || wikidata_faction
+  end
+
+  def party_id
+    super || party_wikidata || wikidata_party
+  end
+
+  def group_id
+    super || group_wikidata || wikidata_group
   end
 end

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -233,5 +233,30 @@ RSpec.describe LoadStatements do
         expect(statement).to_not be_duplicate
       end
     end
+
+    context 'items alternate columns in upstream source' do
+      let(:suggestions_store_response) do
+        <<~CSV
+          name,id,alliance,wikidata_alliance,constituency,constituency_id
+          Alice,Q123,Aparty,Q456,Ambridge,Q789
+        CSV
+      end
+
+      let(:statement) { Statement.last }
+
+      before do
+        load_statements = LoadStatements.new(page.title)
+        expect { load_statements.run }.to change(Statement, :count).by(1)
+      end
+
+      it 'should map alternate columns' do
+        expect(statement.person_name).to eq 'Alice'
+        expect(statement.person_item).to eq 'Q123'
+        expect(statement.parliamentary_group_name).to eq 'Aparty'
+        expect(statement.parliamentary_group_item).to eq 'Q456'
+        expect(statement.electoral_district_name).to eq 'Ambridge'
+        expect(statement.electoral_district_item).to eq 'Q789'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #534 

I haven't added specs for every column alias as it seems like it would be testing the same thing over and over again.