### PR TITLE
[#534] Matched CSV columns values could be not QIDs

### DIFF
--- a/app/services/load_statements.rb
+++ b/app/services/load_statements.rb
@@ -52,7 +52,7 @@ class Row < OpenStruct
   end
 
   def electoral_district_item
-    super || area_id || constituency_id || district_id
+    find_qids(super, area_id, constituency_id, district_id).first
   end
 
   def parliamentary_group_name
@@ -60,7 +60,7 @@ class Row < OpenStruct
   end
 
   def parliamentary_group_item
-    super || alliance_id || coalition_id || faction_id || party_id || group_id
+    find_qids(super, alliance_id, coalition_id, faction_id, party_id, group_id).first
   end
 
   def person_name
@@ -68,7 +68,7 @@ class Row < OpenStruct
   end
 
   def person_item
-    super || id || wikidata
+    find_qids(super, wikidata, id).first
   end
 
   def position_start
@@ -116,34 +116,38 @@ class Row < OpenStruct
   end
 
   def area_id
-    super || area_wikidata || wikidata_area
+    find_qids(super, area_wikidata, wikidata_area).first
   end
 
   def constituency_id
-    super || constituency_wikidata || wikidata_constituency
+    find_qids(super, constituency_wikidata, wikidata_constituency).first
   end
 
   def district_id
-    super || district_wikidata || wikidata_district
+    find_qids(super, district_wikidata, wikidata_district).first
   end
 
   def alliance_id
-    super || alliance_wikidata || wikidata_alliance
+    find_qids(super, alliance_wikidata, wikidata_alliance).first
   end
 
   def coalition_id
-    super || coalition_wikidata || wikidata_coalition
+    find_qids(super, coalition_wikidata, wikidata_coalition).first
   end
 
   def faction_id
-    super || faction_wikidata || wikidata_faction
+    find_qids(super, faction_wikidata, wikidata_faction).first
   end
 
   def party_id
-    super || party_wikidata || wikidata_party
+    find_qids(super, party_wikidata, wikidata_party).first
   end
 
   def group_id
-    super || group_wikidata || wikidata_group
+    find_qids(super, group_wikidata, wikidata_group).first
+  end
+
+  def find_qids(*args)
+    args.select { |id| id && id =~ /^Q\d+$/ }
   end
 end

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -264,23 +264,34 @@ RSpec.describe LoadStatements do
         <<~CSV
           id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender,wikidata,wikidata_group,wikidata_area
           c216f406-b11f-4f2b-a890-e9922293478e,Anthony Martinez,Anthony Martinez,,,,United Democratic Party,90ee4fde-68d6-4544-bb2a-2a58371b629f,7764e1c2-da2a-456f-9ab1-d66665df244d,Port Loyola,House of Representatives,9,,,http://nationalassembly.gov.bz/images/house_of_rep/a_martinez.jpg,male,Q4773030,Q1809323,Q16975862
+          5a76ebe1-9913-4008-83fd-f7ea1e95c26a,Dr. Marco Tulio Mendez,Dr. Marco Tulio Mendez,,,,People's United Party,8e327a03-68fd-4ea0-bd59-b59cb05ecfd6,78a91d5b-a813-4367-aab8-cf6aa6934ac1,Orange Walk East,House of Representatives,9,,,http://nationalassembly.gov.bz/images/house_of_rep/marco%20tulio.jpg,male,,Q1759613,Q25405052
         CSV
       end
 
-      let(:statement) { Statement.last }
+      let(:statement_1) { Statement.find_by(person_name: 'Anthony Martinez') }
+      let(:statement_2) { Statement.find_by(person_name: 'Dr. Marco Tulio Mendez') }
 
       before do
         load_statements = LoadStatements.new(page.title)
-        expect { load_statements.run }.to change(Statement, :count).by(1)
+        expect { load_statements.run }.to change(Statement, :count).by(2)
       end
 
       it 'should map alternate columns' do
-        expect(statement.person_name).to eq 'Anthony Martinez'
-        expect(statement.person_item).to eq 'Q4773030'
-        expect(statement.parliamentary_group_name).to eq 'United Democratic Party'
-        expect(statement.parliamentary_group_item).to eq 'Q1809323'
-        expect(statement.electoral_district_name).to eq 'Port Loyola'
-        expect(statement.electoral_district_item).to eq 'Q16975862'
+        expect(statement_1.person_name).to eq 'Anthony Martinez'
+        expect(statement_1.person_item).to eq 'Q4773030'
+        expect(statement_1.parliamentary_group_name).to eq 'United Democratic Party'
+        expect(statement_1.parliamentary_group_item).to eq 'Q1809323'
+        expect(statement_1.electoral_district_name).to eq 'Port Loyola'
+        expect(statement_1.electoral_district_item).to eq 'Q16975862'
+      end
+
+      it 'should map to nil if alternate columns are invalid' do
+        expect(statement_2.person_name).to eq 'Dr. Marco Tulio Mendez'
+        expect(statement_2.person_item).to be_nil
+        expect(statement_2.parliamentary_group_name).to eq "People's United Party"
+        expect(statement_2.parliamentary_group_item).to eq 'Q1759613'
+        expect(statement_2.electoral_district_name).to eq 'Orange Walk East'
+        expect(statement_2.electoral_district_item).to eq 'Q25405052'
       end
     end
   end

--- a/spec/services/load_statements_spec.rb
+++ b/spec/services/load_statements_spec.rb
@@ -258,5 +258,30 @@ RSpec.describe LoadStatements do
         expect(statement.electoral_district_item).to eq 'Q789'
       end
     end
+
+    context 'use an EveryPolitician CSV as the upstream source' do
+      let(:suggestions_store_response) do
+        <<~CSV
+          id,name,sort_name,email,twitter,facebook,group,group_id,area_id,area,chamber,term,start_date,end_date,image,gender,wikidata,wikidata_group,wikidata_area
+          c216f406-b11f-4f2b-a890-e9922293478e,Anthony Martinez,Anthony Martinez,,,,United Democratic Party,90ee4fde-68d6-4544-bb2a-2a58371b629f,7764e1c2-da2a-456f-9ab1-d66665df244d,Port Loyola,House of Representatives,9,,,http://nationalassembly.gov.bz/images/house_of_rep/a_martinez.jpg,male,Q4773030,Q1809323,Q16975862
+        CSV
+      end
+
+      let(:statement) { Statement.last }
+
+      before do
+        load_statements = LoadStatements.new(page.title)
+        expect { load_statements.run }.to change(Statement, :count).by(1)
+      end
+
+      it 'should map alternate columns' do
+        expect(statement.person_name).to eq 'Anthony Martinez'
+        expect(statement.person_item).to eq 'Q4773030'
+        expect(statement.parliamentary_group_name).to eq 'United Democratic Party'
+        expect(statement.parliamentary_group_item).to eq 'Q1809323'
+        expect(statement.electoral_district_name).to eq 'Port Loyola'
+        expect(statement.electoral_district_item).to eq 'Q16975862'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #534

EveryPolitician CSV contain UUIDs in some matched columns so lets explicitly check for QIDs.