### PR TITLE
Allow new person label to be configured on pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,7 +78,7 @@ class PagesController < ApplicationController
                                  :country_id,
                                  :csv_source_url, :executive_position,
                                  :reference_url_title, :reference_url_language,
-                                 :archived)
+                                 :archived, :new_item_description_en)
   end
 
   def new_page_params

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -137,7 +137,7 @@ export default template({
         },
         {
           lang: 'en',
-          value: this.country.description_en
+          value: this.page.new_item_description_en || this.country.description_en
         }
       ).then(createdItemData => {
         this.reconcileWithItem(createdItemData.item)

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -43,6 +43,13 @@
     </div>
     <%= f.error_span(:reference_url) %>
   </div>
+  <div class="form-group">
+    <%= f.label :new_item_description_en, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_item_description_en, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_item_description_en) %>
+  </div>
   <!--
   <div class="form-group">
     <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -20,6 +20,8 @@
   <dd><%= @page.parliamentary_term_name %> (<%= @page.parliamentary_term_item %>)</dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= @page.reference_url %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_item_description_en) %>:</strong></dt>
+  <dd><%= @page.new_item_description_en %></dd>
   <!--
   <dt><strong><%= model_class.human_attribute_name(:reference_url_title) %>:</strong></dt>
   <dd><%= @page.reference_url_title %></dd>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -44,6 +44,6 @@ json.statements @classifier.to_a do |statement|
   json.bulk_update @bulk_update
 end
 
-json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language
+json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language, :new_item_description_en
 
 json.country @classifier.page.country

--- a/db/migrate/20181121143151_add_description_to_pages.rb
+++ b/db/migrate/20181121143151_add_description_to_pages.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :new_item_description_en, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_12_155901) do
+ActiveRecord::Schema.define(version: 2018_11_21_143151) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2018_11_12_155901) do
     t.string "parliamentary_term_name"
     t.integer "hash_epoch", default: 2
     t.boolean "archived", default: false, null: false
+    t.string "new_item_description_en"
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 


### PR DESCRIPTION
This adds a new column called `new_item_description_en` to the `pages` table. This column is intended to be the same as the `countries.description_en` column, but putting it on the page means we can make it configurable on-wiki.

Fixes https://github.com/mysociety/verification-pages/issues/530