### PR TITLE
SPARQL results refactor

### DIFF
--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -17,7 +17,8 @@ module SparqlResult
   end
 
   def datatype(attr)
-    fetch(attr, {})[:datatype]
+    value = fetch(attr, {})
+    value[:datatype] if value.is_a?(Hash)
   end
 
   private
@@ -31,10 +32,9 @@ module SparqlResult
   end
 
   def method_missing(attr, *args)
-    bool_attr = attr.to_s.match(/(.*?)\??$/)[1].to_sym
-    datatype = fetch(bool_attr, {})[:datatype]
+    bool_attr = attr[/(.*?)\??$/, 1].to_sym
 
-    return self[bool_attr] if datatype == DATATYPE_BOOLEAN
+    return self[bool_attr] if datatype(bool_attr) == DATATYPE_BOOLEAN
     return super unless variables.include?(attr)
 
     self[attr]

--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -12,6 +12,7 @@ module SparqlResult
     value = super
 
     return map_hash(value) if value.is_a?(Hash)
+    return extend_array(value) if value.is_a?(Array)
 
     value
   end
@@ -46,5 +47,9 @@ module SparqlResult
     return hash[:value].to_s.split('/').last if hash[:type] == 'uri'
 
     hash[:value]
+  end
+
+  def extend_array(array)
+    array.map { |item| item.extend(SparqlResult) }
   end
 end

--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -11,7 +11,6 @@ module SparqlResult
   def [](*args)
     value = super
 
-    return nil unless value
     return map_hash(value) if value.is_a?(Hash)
 
     value

--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -11,7 +11,7 @@ module SparqlResult
   def [](*args)
     value = super
     return nil unless value
-    map_value(value)
+    return map_hash(value) if value.is_a?(Hash)
   end
 
   def datatype(attr)
@@ -37,11 +37,11 @@ module SparqlResult
     self[attr]
   end
 
-  def map_value(h)
-    return h[:value] == 'true' if h[:datatype] == DATATYPE_BOOLEAN
-    return h[:value].to_s[0..9] if h[:datatype] == DATATYPE_DATETIME
-    return h[:value].to_s.split('/').last if h[:type] == 'uri'
+  def map_hash(hash)
+    return hash[:value] == 'true' if hash[:datatype] == DATATYPE_BOOLEAN
+    return hash[:value].to_s[0..9] if hash[:datatype] == DATATYPE_DATETIME
+    return hash[:value].to_s.split('/').last if hash[:type] == 'uri'
 
-    h[:value]
+    hash[:value]
   end
 end

--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -23,7 +23,7 @@ module SparqlResult
   private
 
   def variables
-    @variables || keys
+    (@variables || []).map(&:to_sym) | keys
   end
 
   def respond_to_missing?(*args)
@@ -35,7 +35,7 @@ module SparqlResult
     datatype = fetch(bool_attr, {})[:datatype]
 
     return self[bool_attr] if datatype == DATATYPE_BOOLEAN
-    return super unless variables.include?(attr.to_s)
+    return super unless variables.include?(attr)
 
     self[attr]
   end

--- a/app/models/sparql_result.rb
+++ b/app/models/sparql_result.rb
@@ -10,8 +10,11 @@ module SparqlResult
 
   def [](*args)
     value = super
+
     return nil unless value
     return map_hash(value) if value.is_a?(Hash)
+
+    value
   end
 
   def datatype(attr)
@@ -31,9 +34,10 @@ module SparqlResult
   def method_missing(attr, *args)
     bool_attr = attr.to_s.match(/(.*?)\??$/)[1].to_sym
     datatype = fetch(bool_attr, {})[:datatype]
-    return self[bool_attr] if datatype == DATATYPE_BOOLEAN
 
+    return self[bool_attr] if datatype == DATATYPE_BOOLEAN
     return super unless variables.include?(attr.to_s)
+
     self[attr]
   end
 

--- a/spec/models/sparql_result_spec.rb
+++ b/spec/models/sparql_result_spec.rb
@@ -57,4 +57,12 @@ RSpec.describe SparqlResult, type: :model do
   it 'will raise NoMethodError for other methods' do
     expect { result.other }.to raise_error(NoMethodError)
   end
+
+  context 'without variables' do
+    let(:variables) { nil }
+
+    it 'returns values based on hash key' do
+      expect(result.string).to eq 'ABC'
+    end
+  end
 end


### PR DESCRIPTION
Required to handle the subclasses for #314.

This improves SPARQL results by being able to handle arrays values. While to won't get arrays normally from the WDQS my intention is to map the results in the `RetrieveItems` service EG:

```
  def run
    run_query(query).each_with_object({}) do |result, memo|
      result[:children] = [
        { item: result.delete(:child), label: result.delete(:child_label) },
      ]

      memo[result[:item]][:children] += result[:children] if memo[result[:item]]
      memo[result[:item]] ||= result
    end
  end
```

