### PR TITLE
[#570] Fix error being raise on `pages/new` action

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -20,7 +20,7 @@ class Page < ApplicationRecord
   end
 
   def new_item_description_en
-    super || country.description_en
+    super || country&.description_en
   end
 
   private

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -85,4 +85,28 @@ RSpec.describe Page, type: :model do
       expect(page.from_suggestions_store?).to eq(false)
     end
   end
+
+  describe '#new_item_description_en' do
+    let(:desc) { 'A description' }
+    let(:country) { build(:country, description_en: 'A country description') }
+    let(:page) { build(:page, new_item_description_en: desc, country: country) }
+
+    subject { page.new_item_description_en }
+
+    it { is_expected.to eq desc }
+
+    context 'without description' do
+      let(:desc) { nil }
+
+      it 'delegates to the Country#description_en' do
+        expect(page.new_item_description_en).to eq('A country description')
+      end
+    end
+
+    context 'without description or country' do
+      let(:desc) { nil }
+      let(:country) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #570

When country is nil we can't obviously access the `description_en` property.