### PR TITLE
[#48] Emit loading event ASAP

### DIFF
--- a/app/javascript/components/actionable.js
+++ b/app/javascript/components/actionable.js
@@ -33,6 +33,8 @@ export default template({
       this.$parent.$emit('log', data)
     },
     updatePositionHeld: function () {
+      this.$parent.$emit('loading', 'Saving')
+
       var personItem = this.statement.person_item
       var item = wikidataClient.setLogger(this.logger).item(personItem)
       var references = {}
@@ -105,8 +107,6 @@ export default template({
           value: this.statement.position_end, type: 'time'
         }
       }
-
-      this.$parent.$emit('loading', 'Saving')
 
       item.latestRevision().then(function (lastRevisionID) {
         return item.updateOrCreateClaim(lastRevisionID, updateData)


### PR DESCRIPTION
We want this to be emitted as soon as possible to prevent users from
double clicking the `Submit to Wikidata` button.

Fixes #48