### PR TITLE
[#304] Detect reconciliations to disambiguation page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/everypolitician/membership-comparison.git
-  revision: 37213df772c43d56fe836faa332335d73bbf4102
+  revision: f3de98279b2d9db5c3a0e01af0acce54075ddb67
   specs:
     membership-comparison (0.1.0)
 

--- a/app/controllers/frontend_controller.rb
+++ b/app/controllers/frontend_controller.rb
@@ -20,6 +20,6 @@ class FrontendController < ApplicationController
   private
 
   def classify_page(page, statements = [])
-    StatementClassifier.new(page.title, transaction_ids: statements.map(&:transaction_id))
+    PageClassifier.new(page.title, transaction_ids: statements.map(&:transaction_id))
   end
 end

--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -22,7 +22,7 @@ class StatementsController < FrontendController
 
     case params[:force_type]
     when 'done'
-      statement.record_actioned!(StatementClassifier::VERSION)
+      statement.record_actioned!(PageClassifier::VERSION)
     when 'manually_actionable'
       statement.report_error!(params[:error_message])
     when 'actionable'

--- a/app/decorators/statement_decorator.rb
+++ b/app/decorators/statement_decorator.rb
@@ -2,11 +2,33 @@
 
 # Decorator with merges statements with up-to-date position held data
 class StatementDecorator < SimpleDelegator
-  attr_accessor :comparison, :type
+  attr_accessor :comparison
 
   def initialize(statement, comparison)
     @comparison = comparison
     super(statement)
+  end
+
+  def type
+    if removed_from_source? && !done_or_reverted?
+      nil
+    elsif removed_from_source? && done_or_reverted?
+      :removed
+    elsif unverifiable?
+      :unverifiable
+    elsif done?
+      :done
+    elsif reverted?
+      :reverted
+    elsif manually_actionable?
+      :manually_actionable
+    elsif actionable?
+      :actionable
+    elsif verified?
+      :reconcilable
+    else
+      :verifiable
+    end
   end
 
   def statement_uuid

--- a/app/services/generate_verification_page.rb
+++ b/app/services/generate_verification_page.rb
@@ -11,13 +11,13 @@ class GenerateVerificationPage < ServiceBase
   end
 
   def run
-    render template, page: page, statements: classified_statements
+    render template, page: page, statements: classify_page
   end
 
   private
 
-  def classified_statements
-    @classified_statements ||= StatementClassifier.new(page.title)
+  def classify_page
+    @classify_page ||= PageClassifier.new(page.title)
   end
 
   def template

--- a/app/services/generate_verification_page.rb
+++ b/app/services/generate_verification_page.rb
@@ -11,7 +11,7 @@ class GenerateVerificationPage < ServiceBase
   end
 
   def run
-    render template, page: page, statements: classify_page
+    render template, page: page, statements: classify_page.statements
   end
 
   private

--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -74,7 +74,9 @@ class PageClassifier
 
       item_data = item_data_for_statement(statement)
 
-      items = { term: parliamentary_term_data, group: item_data[statement.parliamentary_group_item] }
+      items = { term:   parliamentary_term_data,
+                person: item_data[statement.person_item],
+                group:  item_data[statement.parliamentary_group_item], }
       items[:district] = item_data[statement.electoral_district_item] unless page.executive_position?
 
       decorated_statement = StatementClassifier.new(
@@ -113,6 +115,7 @@ class PageClassifier
   def items
     @items ||= begin
       item_values = @statements.each_with_object([]) do |statement, memo|
+        memo << statement.person_item
         memo << statement.parliamentary_group_item
         memo << statement.electoral_district_item
       end.compact.uniq << page.position_held_item

--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -2,7 +2,8 @@
 
 require 'membership_comparison'
 
-# Service to classify statements into actionable, manually_actionable or done groups
+# Service to classify a page's statements into groups based on if we can submit
+# data to Wikidata or not
 class PageClassifier
   attr_reader :page, :transaction_id
 
@@ -142,58 +143,5 @@ class PageClassifier
 
   def merged_then_deleted(data)
     data.merged_then_deleted.split.map { |item| item.split('/').last }
-  end
-end
-
-class StatementClassifier
-  def initialize(statement:, existing_statements:, items:)
-    @statement = statement
-    @existing_statements = existing_statements
-    @items = items
-  end
-
-  def decorate
-    StatementDecorator.new(@statement, comparison)
-  end
-
-  private
-
-  def comparison
-    MembershipComparison.new(
-      existing:   existing_statements,
-      suggestion: suggested_statement
-    )
-  end
-
-  def existing_statements
-    @existing_statements.each_with_object({}) do |data, memo|
-      memo[data.position] = {
-        start:    data.position_start,
-        end:      data.position_end,
-        term:     {
-          id:    data.term,
-          start: data.term_start,
-          end:   data.term_end,
-        },
-        party:    { id: data.group },
-        district: { id: data.district },
-      }
-    end
-  end
-
-  def suggested_statement
-    {
-      term:     {
-        id:    @items[:term]&.term,
-        start: @items[:term]&.start,
-        end:   @items[:term]&.end,
-        eopt:  @items[:term]&.previous_term_end,
-        sont:  @items[:term]&.next_term_start,
-      },
-      party:    { id: @items[:group]&.item },
-      district: { id: @items[:district]&.item },
-      start:    @statement.position_start,
-      end:      @statement.position_end,
-    }
   end
 end

--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -3,7 +3,7 @@
 require 'membership_comparison'
 
 # Service to classify statements into actionable, manually_actionable or done groups
-class StatementClassifier
+class PageClassifier
   attr_reader :page, :statements, :transaction_id
 
   VERSION = 'v2'

--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -4,7 +4,7 @@ require 'membership_comparison'
 
 # Service to classify statements into actionable, manually_actionable or done groups
 class PageClassifier
-  attr_reader :page, :statements, :transaction_id
+  attr_reader :page, :transaction_id
 
   VERSION = 'v2'
 
@@ -61,18 +61,18 @@ class PageClassifier
     classified_statements.fetch(:removed, [])
   end
 
-  def to_a
+  def statements
     update_page_position_if_merged
 
-    statements.to_a
-              .map { |s| decorate_statement(s) }
-              .select(&:type) # remove statements without a type
+    @statements.to_a
+               .map { |s| decorate_statement(s) }
+               .select(&:type) # remove statements without a type
   end
 
   private
 
   def classified_statements
-    @classified_statements ||= to_a.each_with_object({}) do |statement, h|
+    @classified_statements ||= statements.each_with_object({}) do |statement, h|
       h[statement.type] ||= []
       h[statement.type] << statement
     end
@@ -80,7 +80,7 @@ class PageClassifier
 
   def person_item_from_transaction_id
     return unless transaction_id
-    statements.first.person_item
+    @statements.first.person_item
   end
 
   def update_page_position_if_merged

--- a/app/services/retrieve_items.rb
+++ b/app/services/retrieve_items.rb
@@ -35,14 +35,19 @@ class RetrieveItems < ServiceBase
   def query_format
     <<~SPARQL
       SELECT
-        ?item ?real_item ?label ?merged
+        ?item ?real_item ?label ?merged ?disambiguation
       WHERE {
         VALUES (?item) {
           %<items>s
         }
+        BIND(wd:Q4167410 AS ?disambiguation_page)
+
         OPTIONAL { ?item owl:sameAs ?real_item }
         BIND(COALESCE(?real_item, ?item) AS ?real_item)
         BIND (?real_item != $item AS ?merged)
+        OPTIONAL { ?real_item wdt:P31 ?instance_of }
+        BIND(?instance_of = ?disambiguation_page AS ?disambiguation) .
+
         SERVICE wikibase:label {
           bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" .
           ?real_item rdfs:label ?label .

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -78,6 +78,34 @@ class StatementClassifier
     end
   end
 
+  def person_item_from_transaction_id
+    return unless transaction_id
+    statements.first.person_item
+  end
+
+  def update_page_position_if_merged
+    page.update(position_held_item: position.real_item) if position&.merged?
+  end
+
+  def position
+    @position ||= RetrieveItems.one(page.position_held_item)
+  end
+
+  def position_held_data
+    return [] unless position&.item
+
+    @position_held_data ||= RetrievePositionData.run(
+      position.item,
+      person_item_from_transaction_id
+    )
+  end
+
+  def parliamentary_term_data
+    @parliamentary_term_data ||= RetrieveTermData.run(
+      page.parliamentary_term_item
+    )
+  end
+
   def statement_type(statement)
     if statement.removed_from_source? && !statement.done_or_reverted?
       nil
@@ -105,34 +133,6 @@ class StatementClassifier
     StatementDecorator.new(statement, comparison).tap do |s|
       s.type = statement_type(s)
     end
-  end
-
-  def person_item_from_transaction_id
-    return unless transaction_id
-    statements.first.person_item
-  end
-
-  def update_page_position_if_merged
-    page.update(position_held_item: position.real_item) if position&.merged?
-  end
-
-  def position
-    @position ||= RetrieveItems.one(page.position_held_item)
-  end
-
-  def position_held_data
-    return [] unless position&.item
-
-    @position_held_data ||= RetrievePositionData.run(
-      position.item,
-      person_item_from_transaction_id
-    )
-  end
-
-  def parliamentary_term_data
-    @parliamentary_term_data ||= RetrieveTermData.run(
-      page.parliamentary_term_item
-    )
   end
 
   def comparison_for_statement(statement)

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Service to classify a statement based on if we can submit data to Wikidata or
+# not.
+class StatementClassifier
+  def initialize(statement:, existing_statements:, items:)
+    @statement = statement
+    @existing_statements = existing_statements
+    @items = items
+  end
+
+  def decorate
+    StatementDecorator.new(@statement, comparison)
+  end
+
+  private
+
+  def comparison
+    MembershipComparison.new(
+      existing:   existing_statements,
+      suggestion: suggested_statement
+    )
+  end
+
+  def existing_statements
+    @existing_statements.each_with_object({}) do |data, memo|
+      memo[data.position] = {
+        start:    data.position_start,
+        end:      data.position_end,
+        term:     {
+          id:    data.term,
+          start: data.term_start,
+          end:   data.term_end,
+        },
+        party:    { id: data.group },
+        district: { id: data.district },
+      }
+    end
+  end
+
+  def suggested_statement
+    {
+      term:     {
+        id:    @items[:term]&.term,
+        start: @items[:term]&.start,
+        end:   @items[:term]&.end,
+        eopt:  @items[:term]&.previous_term_end,
+        sont:  @items[:term]&.next_term_start,
+      },
+      party:    { id: @items[:group]&.item },
+      district: { id: @items[:district]&.item },
+      start:    @statement.position_start,
+      end:      @statement.position_end,
+    }
+  end
+end

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -47,8 +47,9 @@ class StatementClassifier
         eopt:  @items[:term]&.previous_term_end,
         sont:  @items[:term]&.next_term_start,
       },
-      party:    { id: @items[:group]&.item },
-      district: { id: @items[:district]&.item },
+      person:   { disambiguation: @items[:person]&.disambiguation },
+      party:    { id: @items[:group]&.item, disambiguation: @items[:group]&.disambiguation },
+      district: { id: @items[:district]&.item, disambiguation: @items[:district]&.disambiguation },
       start:    @statement.position_start,
       end:      @statement.position_end,
     }

--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -106,33 +106,9 @@ class StatementClassifier
     )
   end
 
-  def statement_type(statement)
-    if statement.removed_from_source? && !statement.done_or_reverted?
-      nil
-    elsif statement.removed_from_source? && statement.done_or_reverted?
-      :removed
-    elsif statement.unverifiable?
-      :unverifiable
-    elsif statement.done?
-      :done
-    elsif statement.reverted?
-      :reverted
-    elsif statement.manually_actionable?
-      :manually_actionable
-    elsif statement.actionable?
-      :actionable
-    elsif statement.verified?
-      :reconcilable
-    else
-      :verifiable
-    end
-  end
-
   def decorate_statement(statement)
     comparison = comparison_for_statement(statement)
-    StatementDecorator.new(statement, comparison).tap do |s|
-      s.type = statement_type(s)
-    end
+    StatementDecorator.new(statement, comparison)
   end
 
   def comparison_for_statement(statement)

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.statements @classifier.to_a do |statement|
+json.statements @classifier.statements do |statement|
   json.call(
     statement,
     :type,

--- a/spec/controllers/reconciliations_controller_spec.rb
+++ b/spec/controllers/reconciliations_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ReconciliationsController, type: :controller do
         before do
           allow(Statement).to receive(:find_by!).and_return(statement)
           allow(statement).to receive(:reconciliations).and_return(relation)
-          allow(StatementClassifier).to receive(:new).and_return(classifier)
+          allow(PageClassifier).to receive(:new).and_return(classifier)
         end
 
         it 'finds statement and creates reconciliation' do
@@ -53,7 +53,7 @@ RSpec.describe ReconciliationsController, type: :controller do
         before do
           allow(Statement).to receive(:find_by!).and_return(statement)
           allow(statement).to receive(:reconciliations).and_return(relation)
-          allow(StatementClassifier).to receive(:new).and_return(classifier)
+          allow(PageClassifier).to receive(:new).and_return(classifier)
         end
 
         it 'finds statement and creates reconciliation' do

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe VerificationsController, type: :controller do
     before do
       allow(Statement).to receive(:find_by!).and_return(statement)
       allow(statement).to receive(:verifications).and_return(relation)
-      allow(StatementClassifier).to receive(:new).and_return(classifier)
+      allow(PageClassifier).to receive(:new).and_return(classifier)
     end
 
     it 'finds statement and creates verification' do

--- a/spec/services/generate_verification_page_spec.rb
+++ b/spec/services/generate_verification_page_spec.rb
@@ -24,15 +24,16 @@ RSpec.describe GenerateVerificationPage, type: :service do
         .with(page.position_held_item)
         .and_return(position_held_data)
 
-      classified_statements = double(:classified_statements)
+      statements = double(:statements)
+      classify_page = double(:classify_page, statements: statements)
       expect(PageClassifier).to receive(:new)
         .with('page_title')
-        .and_return(classified_statements)
+        .and_return(classify_page)
 
       template = Rails.root.join('app', 'views', 'wiki', 'verification.mediawiki.erb')
 
       expect(service).to receive(:render)
-        .with(template, page: page, statements: classified_statements)
+        .with(template, page: page, statements: statements)
 
       service.run
     end

--- a/spec/services/generate_verification_page_spec.rb
+++ b/spec/services/generate_verification_page_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GenerateVerificationPage, type: :service do
         .and_return(position_held_data)
 
       classified_statements = double(:classified_statements)
-      expect(StatementClassifier).to receive(:new)
+      expect(PageClassifier).to receive(:new)
         .with('page_title')
         .and_return(classified_statements)
 

--- a/spec/services/page_classifier_spec.rb
+++ b/spec/services/page_classifier_spec.rb
@@ -57,14 +57,13 @@ RSpec.describe PageClassifier, type: :service do
   end
 
   describe 'initialisation' do
-    it 'assigns instance variables' do
+    it 'assigns #page instance variables' do
       expect(classifier.page).to eq page
-      expect(classifier.statements).to eq statements
     end
   end
 
-  describe '#to_a' do
-    subject { classifier.to_a }
+  describe '#statements' do
+    subject { classifier.statements }
 
     it 'should return decorated statements' do
       is_expected.to include(a_kind_of(StatementDecorator))

--- a/spec/services/page_classifier_spec.rb
+++ b/spec/services/page_classifier_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe StatementClassifier, type: :service do
+RSpec.describe PageClassifier, type: :service do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:page) do
@@ -32,7 +32,7 @@ RSpec.describe StatementClassifier, type: :service do
     )
   end
 
-  let(:classifier) { StatementClassifier.new('page_title') }
+  let(:classifier) { PageClassifier.new('page_title') }
 
   before do
     stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')

--- a/spec/services/page_classifier_spec.rb
+++ b/spec/services/page_classifier_spec.rb
@@ -81,9 +81,8 @@ RSpec.describe PageClassifier, type: :service do
         merged?:   true
       )
 
-      allow(RetrieveItems).to receive(:one)
-        .with(page.position_held_item)
-        .and_return(position)
+      allow(RetrieveItems).to receive(:run)
+        .and_return(page.position_held_item => position)
 
       expect { subject }.to change(page, :position_held_item).to('Q123')
     end

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe StatementClassifier, type: :service do
     end
 
     it 'should not return items without types' do
-      allow(classifier).to receive(:statement_type).and_return(nil)
+      allow_any_instance_of(StatementDecorator).to receive(:type).and_return(nil)
       is_expected.to match_array([])
     end
 

--- a/spec/services/statement_classifier_spec.rb
+++ b/spec/services/statement_classifier_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe StatementClassifier, type: :service do
   let(:data) { { person_item: 'Q1' } }
   let(:statement) { build(:statement, data.merge(page: page)) }
   let(:statements) { [statement].compact }
-  let(:statement_relation) { double(:relation, to_a: statements) }
 
   let(:wikidata_data) do
     { person: 'Q1', merged_then_deleted: '', position: 'UUID' }
@@ -37,14 +36,12 @@ RSpec.describe StatementClassifier, type: :service do
 
   before do
     stub_const('SuggestionsStore::Request::URL', 'http://suggestions-store/')
-    allow(statement_relation).to receive_message_chain(
-      :original, :includes, :references, :order
-    ).and_return(statement_relation)
     allow(Page).to receive(:find_by!)
       .with(title: 'page_title')
       .and_return(page)
-    allow(page).to receive(:statements)
-      .and_return(statement_relation)
+    allow(page).to receive_message_chain(
+      :statements, :original, :includes, :references, :order
+    ).and_return(statements)
 
     allow(RetrieveItems).to receive(:one)
       .with(page.position_held_item)
@@ -62,7 +59,7 @@ RSpec.describe StatementClassifier, type: :service do
   describe 'initialisation' do
     it 'assigns instance variables' do
       expect(classifier.page).to eq page
-      expect(classifier.statements).to eq statement_relation
+      expect(classifier.statements).to eq statements
     end
   end
 


### PR DESCRIPTION
Fixes #304 

Classify statements as `manually actionable` if the person/ party/ district have been reconciled to a disambiguation page to prevent creating P39s. Users can edit the reconciliation to resolve the action the statement.

Commits ee1016c...441bb8f are basically a refactor to facilitate the help make the change required as small as possible.