### PR TITLE
[#586] Fix incorrect states

### DIFF
--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -110,11 +110,11 @@ class PageClassifier
   end
 
   def position
-    @position ||= items[page.position_held_item]
+    @position ||= item_data[page.position_held_item]
   end
 
-  def items
-    @items ||= begin
+  def item_data
+    @item_data ||= begin
       item_values = @statements.each_with_object([]) do |statement, memo|
         memo << statement.person_item
         memo << statement.parliamentary_group_item
@@ -127,7 +127,7 @@ class PageClassifier
 
   def item_data_for_statement(statement)
     item_values = [statement.person_item, statement.parliamentary_group_item, statement.electoral_district_item]
-    items.select { |k| item_values.include?(k) }
+    item_data.select { |k| item_values.include?(k) }
   end
 
   def position_held_data

--- a/app/services/page_classifier.rb
+++ b/app/services/page_classifier.rb
@@ -72,8 +72,6 @@ class PageClassifier
         person_items.include?(statement.person_item)
       end
 
-      item_data = item_data_for_statement(statement)
-
       items = { position: item_data[page.position_held_item],
                 term:     parliamentary_term_data,
                 person:   item_data[statement.person_item],
@@ -123,11 +121,6 @@ class PageClassifier
 
       RetrieveItems.run(*item_values)
     end
-  end
-
-  def item_data_for_statement(statement)
-    item_values = [statement.person_item, statement.parliamentary_group_item, statement.electoral_district_item]
-    item_data.select { |k| item_values.include?(k) }
   end
 
   def position_held_data


### PR DESCRIPTION
Fixes #586 

This removes filtering of item data before passing it through to the `StatementClassifier`. The position data was being removed but is now required.

Without the position data the membership-comparison gem was ignoring the existing statements as the positions didn't match and caused the frontend to show the 'Submit to Wikidata' button for virtually all statements.