### PR TITLE
[#401] Move label language over to Page class

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,7 +78,8 @@ class PagesController < ApplicationController
                                  :country_id,
                                  :csv_source_url, :executive_position,
                                  :reference_url_title, :reference_url_language,
-                                 :archived, :new_item_description_en)
+                                 :archived, :new_item_description_en,
+                                 :new_item_label_language)
   end
 
   def new_page_params

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -132,7 +132,7 @@ export default template({
     createPerson: function () {
       wikidataClient.createPerson(
         {
-          lang: this.country.label_lang,
+          lang: this.page.new_item_label_language,
           value: this.searchTerm
         },
         {

--- a/app/lib/wiki_page_template_tag.rb
+++ b/app/lib/wiki_page_template_tag.rb
@@ -17,6 +17,7 @@ class WikiPageTemplateTag
       parliamentary_term_item: params[:parliamentary_term_item],
       csv_source_url:          params[:csv_source_url],
       new_item_description_en: params[:new_item_description_en],
+      new_item_label_language: params[:new_item_label_language],
     }
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,10 @@ class Page < ApplicationRecord
     super || country&.description_en
   end
 
+  def new_item_label_language
+    super || country&.label_lang
+  end
+
   private
 
   def set_position_held_name

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -50,6 +50,13 @@
     </div>
     <%= f.error_span(:new_item_description_en) %>
   </div>
+  <div class="form-group">
+    <%= f.label :new_item_label_language, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_item_label_language, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_item_label_language) %>
+  </div>
   <!--
   <div class="form-group">
     <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -11,6 +11,7 @@
       <th><%= model_class.human_attribute_name(:position_held_item) %></th>
       <th><%= model_class.human_attribute_name(:parliamentary_term_item) %></th>
       <th><%= model_class.human_attribute_name(:new_item_description_en) %></th>
+      <th><%= model_class.human_attribute_name(:new_item_label_language) %></th>
       <th><%= model_class.human_attribute_name(:executive_position) %></th>
       <th><%= model_class.human_attribute_name(:archived) %></th>
       <th><%= t '.actions', default: t("helpers.actions") %></th>
@@ -25,6 +26,7 @@
         <td><%= link_to_wiki page.position_held_name, page.position_held_item %></td>
         <td><%= link_to_wiki page.parliamentary_term_name, page.parliamentary_term_item %></td>
         <td><%= page.new_item_description_en %></td>
+        <td><%= page.new_item_label_language %></td>
         <td><%= page.executive_position %></td>
         <td><%= page.archived %></td>
         <td>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -28,6 +28,8 @@
   <dd><%= link_to @page.csv_source_url %></dd>
   <dt><strong><%= model_class.human_attribute_name(:new_item_description_en) %>:</strong></dt>
   <dd><%= @page.new_item_description_en %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_item_label_language) %>:</strong></dt>
+  <dd><%= @page.new_item_label_language %></dd>
   <dt><strong><%= model_class.human_attribute_name(:executive_position) %>:</strong></dt>
   <dd><%= @page.executive_position %></dd>
   <dt><strong><%= model_class.human_attribute_name(:archived) %>:</strong></dt>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -45,6 +45,6 @@ json.statements @classifier.statements do |statement|
   json.bulk_update @bulk_update
 end
 
-json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language, :new_item_description_en
+json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language, :new_item_description_en, :new_item_label_language
 
-json.country @classifier.page.country, :label_lang
+json.country @classifier.page.country

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,4 +42,5 @@ en:
         reference_url_title: Reference URL title
         reference_url_language: Reference URL language
         new_item_description_en: Item description
+        new_item_label_language: Item label language
         csv_source_url: CSV source URL

--- a/db/migrate/20190201152207_add_new_item_label_language_to_pages.rb
+++ b/db/migrate/20190201152207_add_new_item_label_language_to_pages.rb
@@ -1,0 +1,5 @@
+class AddNewItemLabelLanguageToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :new_item_label_language, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_21_143151) do
+ActiveRecord::Schema.define(version: 2019_02_01_152207) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2018_11_21_143151) do
     t.integer "hash_epoch", default: 2
     t.boolean "archived", default: false, null: false
     t.string "new_item_description_en"
+    t.string "new_item_label_language"
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/controllers/wikidata_page_controller_spec.rb
+++ b/spec/controllers/wikidata_page_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe WikidataPageController, type: :controller do
           parliamentary_term_item: 'Q456',
           csv_source_url:          'https://example.com/members.csv',
           new_item_description_en: 'Canadian politician',
+          new_item_label_language: 'en',
         },
         update_page:     true,
         wikidata_url:    wikidata_url

--- a/spec/lib/wiki_page_template_tag_spec.rb
+++ b/spec/lib/wiki_page_template_tag_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe WikiPageTemplateTag, type: :service do
       |parliamentary_term_item=Q456
       |csv_source_url=https://example.com/members.csv
       |new_item_description_en=Canadian politician
+      |new_item_label_language=en
       }}
     TEMPLATE
   end
@@ -50,7 +51,8 @@ RSpec.describe WikiPageTemplateTag, type: :service do
         position_held_item:      'Q123',
         parliamentary_term_item: 'Q456',
         csv_source_url:          'https://example.com/members.csv',
-        new_item_description_en: 'Canadian politician'
+        new_item_description_en: 'Canadian politician',
+        new_item_label_language: 'en'
       )
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -109,4 +109,28 @@ RSpec.describe Page, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#new_item_label_language' do
+    let(:lang) { 'en' }
+    let(:country) { build(:country, label_lang: 'ca') }
+    let(:page) { build(:page, new_item_label_language: lang, country: country) }
+
+    subject { page.new_item_label_language }
+
+    it { is_expected.to eq lang }
+
+    context 'without label language' do
+      let(:lang) { nil }
+
+      it 'delegates to the Country#label_lang' do
+        expect(page.new_item_label_language).to eq('ca')
+      end
+    end
+
+    context 'without label language or country' do
+      let(:lang) { nil }
+      let(:country) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #401 

Checklist from #531

> - [x] move the `label_lang` from the Country model to the Page model
> - [x] accept `label_lang` from wiki template tag
> - [x] double check the current `Country#description_en` values have been migrated to `Page#new_item_description_en` - see command on PR

#### Post deploy

We should run:
 ```sql
UPDATE pages AS p
INNER JOIN countries AS c ON c.id = p.country_id
SET
  p.new_item_description_en = COALESCE(p.new_item_description_en, c.description_en),
  p.new_item_label_language = COALESCE(p.new_item_label_language, c.label_lang)
```