### PR TITLE
[#458] Add page country fields

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -75,7 +75,7 @@ class PagesController < ApplicationController
   def page_params
     params.require(:page).permit(:title, :position_held_item,
                                  :parliamentary_term_item, :reference_url,
-                                 :country_id,
+                                 :country_id, :country_item, :country_code,
                                  :csv_source_url, :executive_position,
                                  :reference_url_title, :reference_url_language,
                                  :archived, :new_item_description_en,

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,6 +14,7 @@ class Page < ApplicationRecord
 
   before_validation :set_position_held_name, if: :position_held_item_changed?
   before_validation :set_parliamentary_term_name, if: :parliamentary_term_item_changed?
+  before_validation :set_country_name, if: :country_item_changed?
 
   def from_suggestions_store?
     URI.parse(csv_source_url).host == URI.parse(SuggestionsStore::Request::URL).host
@@ -29,7 +30,11 @@ class Page < ApplicationRecord
     self.parliamentary_term_name = item_data[parliamentary_term_item]&.label
   end
 
+  def set_country_name
+    self.country_name = item_data[country_item]&.label
+  end
+
   def item_data
-    @item_data ||= RetrieveItems.run(position_held_item, parliamentary_term_item)
+    @item_data ||= RetrieveItems.run(position_held_item, parliamentary_term_item, country_item)
   end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -37,6 +37,20 @@
     <%= f.error_span(:parliamentary_term_item) %>
   </div>
   <div class="form-group">
+    <%= f.label :country_item, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :country_item, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:country_item) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :country_code, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :country_code, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:country_code) %>
+  </div>
+  <div class="form-group">
     <%= f.label :reference_url, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
       <%= f.text_field :reference_url, class: 'form-control' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,6 +10,7 @@
       <th><%= model_class.human_attribute_name(:country) %></th>
       <th><%= model_class.human_attribute_name(:position_held_item) %></th>
       <th><%= model_class.human_attribute_name(:parliamentary_term_item) %></th>
+      <th><%= model_class.human_attribute_name(:country_item) %></th>
       <th><%= model_class.human_attribute_name(:new_item_description_en) %></th>
       <th><%= model_class.human_attribute_name(:new_item_label_language) %></th>
       <th><%= model_class.human_attribute_name(:executive_position) %></th>
@@ -25,6 +26,7 @@
         <td><%= link_to page.country.name, page.country %></td>
         <td><%= link_to_wiki page.position_held_name, page.position_held_item %></td>
         <td><%= link_to_wiki page.parliamentary_term_name, page.parliamentary_term_item %></td>
+        <td><%= link_to_wiki page.country_name, page.country_item %></td>
         <td><%= page.new_item_description_en %></td>
         <td><%= page.new_item_label_language %></td>
         <td><%= page.executive_position %></td>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -16,6 +16,10 @@
   <dd><%= link_to_wiki @page.position_held_name, @page.position_held_item %></dd>
   <dt><strong><%= model_class.human_attribute_name(:parliamentary_term_item) %>:</strong></dt>
   <dd><%= link_to_wiki @page.parliamentary_term_name, @page.parliamentary_term_item %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:country_item) %>:</strong></dt>
+  <dd><%= link_to_wiki @page.country_name, @page.country_item %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:country_code) %>:</strong></dt>
+  <dd><%= @page.country_code %></dd>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= link_to @page.reference_url %></dd>
   <!--

--- a/db/migrate/20190212141742_add_country_fields_to_pages.rb
+++ b/db/migrate/20190212141742_add_country_fields_to_pages.rb
@@ -1,0 +1,7 @@
+class AddCountryFieldsToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :country_item, :string
+    add_column :pages, :country_name, :string
+    add_column :pages, :country_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_140123) do
+ActiveRecord::Schema.define(version: 2019_02_12_141742) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -38,6 +38,9 @@ ActiveRecord::Schema.define(version: 2019_02_12_140123) do
     t.boolean "archived", default: false, null: false
     t.string "new_item_description_en"
     t.string "new_item_label_language"
+    t.string "country_item"
+    t.string "country_name"
+    t.string "country_code"
     t.index ["country_id"], name: "index_pages_on_country_id"
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -28,12 +28,15 @@ RSpec.describe Page, type: :model do
   end
 
   describe 'before validation' do
-    let(:page) { build(:page, position_held_item: 'Q2', parliamentary_term_item: 'Q3') }
+    let(:page) do
+      build(:page, position_held_item: 'Q2', parliamentary_term_item: 'Q3', country_item: 'Q4')
+    end
 
     before do
-      allow(RetrieveItems).to receive(:run).with('Q2', 'Q3').and_return(
+      allow(RetrieveItems).to receive(:run).with('Q2', 'Q3', 'Q4').and_return(
         'Q2' => OpenStruct.new(label: 'Position'),
-        'Q3' => OpenStruct.new(label: 'Term')
+        'Q3' => OpenStruct.new(label: 'Term'),
+        'Q4' => OpenStruct.new(label: 'Country')
       )
     end
 
@@ -66,6 +69,22 @@ RSpec.describe Page, type: :model do
 
       it 'should not set position held name' do
         expect { page.valid? }.to_not change(page, :parliamentary_term_name)
+      end
+    end
+
+    context 'country item changed' do
+      before { allow(page).to receive(:country_item_changed?) { true } }
+
+      it 'should set country name' do
+        expect { page.valid? }.to change(page, :country_name).to('Country')
+      end
+    end
+
+    context 'position held item is unchanged' do
+      before { allow(page).to receive(:country_item_changed?) { false } }
+
+      it 'should not set position held name' do
+        expect { page.valid? }.to_not change(page, :country_name)
       end
     end
   end


### PR DESCRIPTION
Connects to #458 & #459 making a start to derive Country from from position held and/or term items.

Checklist from #531

> - [x] add `Page#country_item` string column
> - [x] add `Page#country_name` string column
> - [x] add `Page#country_code` string column
> - [x] add `Page#country_item` to new page form
> - [x] add `Page#country_item` and `Page#country_name` to Page show and index views
> - [x] optional - setup automatic loading of `country_name`, like how `position_held_name`, `parliamentary_term_name` are retrieved from a SPARQL query - so we have countries names for new Verification Pages
> - [x] migrate existing `Country#wikidata_id` values have been migrated to `Page#country_item` - see command on PR #597 
> - [x] migrate existing `Country#name` values have been migrated to `Page#country_name` - see command on PR #597
> - [x] migrate existing `Country#code` values have been migrated to `Page#country_code` - see command on PR #597

#### Post deploy

We should run:
 ```sql
UPDATE pages AS p
INNER JOIN countries AS c ON c.id = p.country_id
SET
  p.country_item = COALESCE(p.country_item, c.wikidata_id),
  p.country_name = COALESCE(p.country_name, c.name),
  p.country_code = COALESCE(p.country_code, c.code)
```