### PR TITLE
[#458] Update transaction ID generation

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,6 +9,7 @@ class Page < ApplicationRecord
 
   validates :title, presence: true, uniqueness: true
   validates :position_held_item, presence: true
+  validates :country_code, presence: true, if: ->(p) { p.hash_epoch <= 2 }
   validates :reference_url, length: { maximum: 2000 }
   validates :csv_source_url, presence: true
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,6 +9,7 @@ class Page < ApplicationRecord
 
   validates :title, presence: true, uniqueness: true
   validates :position_held_item, presence: true
+  validates :country_item, presence: true, if: ->(p) { p.hash_epoch >= 3 }
   validates :country_code, presence: true, if: ->(p) { p.hash_epoch <= 2 }
   validates :reference_url, length: { maximum: 2000 }
   validates :csv_source_url, presence: true

--- a/app/models/page/transaction_id.rb
+++ b/app/models/page/transaction_id.rb
@@ -17,6 +17,7 @@ class Page
       case hash_epoch
       when 1 then { country: country_code }
       when 2 then { country: country_code, page: id }
+      when 3 then { country: country_item, page: id }
       else raise UnknownHashEpochError
       end
     end

--- a/app/models/page/transaction_id.rb
+++ b/app/models/page/transaction_id.rb
@@ -15,8 +15,8 @@ class Page
       # IDs resulting in duplicate Statements being created when page CSV
       # sources are next fetched
       case hash_epoch
-      when 1 then { country: country.code }
-      when 2 then { country: country.code, page: id }
+      when 1 then { country: country_code }
+      when 2 then { country: country_code, page: id }
       else raise UnknownHashEpochError
       end
     end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -43,6 +43,7 @@
     </div>
     <%= f.error_span(:country_item) %>
   </div>
+  <% if @page.hash_epoch <= 2 %>
   <div class="form-group">
     <%= f.label :country_code, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">
@@ -50,6 +51,7 @@
     </div>
     <%= f.error_span(:country_code) %>
   </div>
+  <% end %>
   <div class="form-group">
     <%= f.label :reference_url, class: 'control-label col-lg-2' %>
     <div class="col-lg-10">

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -18,8 +18,10 @@
   <dd><%= link_to_wiki @page.parliamentary_term_name, @page.parliamentary_term_item %></dd>
   <dt><strong><%= model_class.human_attribute_name(:country_item) %>:</strong></dt>
   <dd><%= link_to_wiki @page.country_name, @page.country_item %></dd>
+  <% if @page.hash_epoch <= 2 %>
   <dt><strong><%= model_class.human_attribute_name(:country_code) %>:</strong></dt>
   <dd><%= @page.country_code %></dd>
+  <% end %>
   <dt><strong><%= model_class.human_attribute_name(:reference_url) %>:</strong></dt>
   <dd><%= link_to @page.reference_url %></dd>
   <!--

--- a/db/migrate/20190214152100_increase_page_has_epoch_3.rb
+++ b/db/migrate/20190214152100_increase_page_has_epoch_3.rb
@@ -1,0 +1,9 @@
+class IncreasePageHasEpoch3 < ActiveRecord::Migration[5.2]
+  def up
+    change_column :pages, :hash_epoch, :integer, default: 3
+  end
+
+  def down
+    change_column :pages, :hash_epoch, :integer, default: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_141742) do
+ActiveRecord::Schema.define(version: 2019_02_14_152100) do
 
   create_table "countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_141742) do
     t.string "reference_url_language"
     t.string "position_held_name"
     t.string "parliamentary_term_name"
-    t.integer "hash_epoch", default: 2
+    t.integer "hash_epoch", default: 3
     t.boolean "archived", default: false, null: false
     t.string "new_item_description_en"
     t.string "new_item_label_language"

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe PagesController, type: :controller do
   let(:valid_attributes) do
     { title: 'Page title', position_held_item: 'Q1',
       parliamentary_term_item: 'Q2', reference_url: 'http://example.com',
-      country_id: country.id, csv_source_url: 'http://example.com/export.csv', executive_position: false,
+      country_id: country.id, country_item: 'Q16', country_code: 'ca',
+      csv_source_url: 'http://example.com/export.csv', executive_position: false,
       reference_url_title: 'Example site', reference_url_language: 'en', }
   end
 

--- a/spec/controllers/wikidata_page_controller_spec.rb
+++ b/spec/controllers/wikidata_page_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe WikidataPageController, type: :controller do
         page_attributes: {
           position_held_item:      'Q123',
           country:                 canada,
+          country_item:            'Q16',
+          country_code:            'ca',
           parliamentary_term_item: 'Q456',
           csv_source_url:          'https://example.com/members.csv',
           new_item_description_en: 'Canadian politician',

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -10,5 +10,7 @@ FactoryBot.define do
     reference_url { 'http://example.com' }
     csv_source_url { 'https://example.com/export.csv' }
     country
+    country_item { 'Q16' }
+    country_code { 'ca' }
   end
 end

--- a/spec/models/page/transaction_id_spec.rb
+++ b/spec/models/page/transaction_id_spec.rb
@@ -38,5 +38,16 @@ RSpec.describe Page::TransactionID, type: :model do
         is_expected.to eq 'md5:def'
       end
     end
+
+    context 'with hash_epoch = 3' do
+      before { page.hash_epoch = 3 }
+
+      it 'should merge the country item and page ID then MD5 stored hash data string' do
+        page.id = 1
+        data_string = 'bar:bar;country:Q16;foo:foo;page:1'
+        expect(Digest::MD5).to receive(:hexdigest).with(data_string) { 'ghi' }
+        is_expected.to eq 'md5:ghi'
+      end
+    end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Page, type: :model do
     it 'requires csv_source_url' do
       expect(page.errors).to include(:csv_source_url)
     end
+
+    context 'hash epoch eq 2' do
+      let(:page) { Page.new(hash_epoch: 2) }
+
+      it 'requires country_code' do
+        expect(page.errors).to include(:country_code)
+      end
+
+      it 'does not requires country_item' do
+        expect(page.errors).not_to include(:country_item)
+      end
+    end
   end
 
   describe 'before validation' do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe Page, type: :model do
         expect(page.errors).not_to include(:country_item)
       end
     end
+
+    context 'hash epoch eq 3' do
+      let(:page) { Page.new(hash_epoch: 3) }
+
+      it 'does not requires country_code' do
+        expect(page.errors).not_to include(:country_code)
+      end
+
+      it 'requires country_item' do
+        expect(page.errors).to include(:country_item)
+      end
+    end
   end
 
   describe 'before validation' do


### PR DESCRIPTION
Connects to #458 & #459 use Page#country_item over Country#code for transaction IDs

Checklist from #531

> - [x] add Page validation to ensure if a page has `hash_epoch == 2` then an ISO country code item is valid - EG 2 or 3 characters
> - [x] change statement transaction ID generation hash from `{ country: country.code, ... }` to `{ country: page.country, ... }` - doesn't need a hash epoch increase as fields have been migrated to Page model
> - [x] increase statement transaction ID hash epoch - so we can differentiate Pages with ISO like country codes and those with Q-IDs
> - [x] add Page validation to ensure if a page has `hash_epoch == 3` then an Q-ID country item is valid

