### PR TITLE
[#459] Derive country from position or terms

### DIFF
--- a/app/lib/wiki_page_template_tag.rb
+++ b/app/lib/wiki_page_template_tag.rb
@@ -12,7 +12,6 @@ class WikiPageTemplateTag
 
   def page_attributes
     {
-      country_item:            params[:country_item],
       position_held_item:      params[:position_held_item],
       parliamentary_term_item: params[:parliamentary_term_item],
       csv_source_url:          params[:csv_source_url],

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -13,6 +13,7 @@ class Page < ApplicationRecord
   validates :reference_url, length: { maximum: 2000 }
   validates :csv_source_url, presence: true
 
+  before_validation :fetch_country
   before_validation :set_position_held_name, if: :position_held_item_changed?
   before_validation :set_parliamentary_term_name, if: :parliamentary_term_item_changed?
   before_validation :set_country_name, if: :country_item_changed?
@@ -22,6 +23,12 @@ class Page < ApplicationRecord
   end
 
   private
+
+  def fetch_country
+    return unless position_held_item_changed? || parliamentary_term_item_changed?
+
+    self.country_item = RetrieveCountry.run(position_held_item, parliamentary_term_item)&.country
+  end
 
   def set_position_held_name
     self.position_held_name = item_data[position_held_item]&.label

--- a/app/services/retrieve_country.rb
+++ b/app/services/retrieve_country.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Fetches country from position held or parliamentary term items from Wikidata.
+class RetrieveCountry < ServiceBase
+  include SparqlQuery
+
+  attr_reader :position_held_item, :parliamentary_term_item
+
+  def initialize(position_held_item, parliamentary_term_item)
+    @position_held_item = position_held_item
+    @parliamentary_term_item = parliamentary_term_item
+  end
+
+  def run
+    run_query(query).first
+  end
+
+  def query
+    query_format % { position_held_item:      position_held_item,
+                     parliamentary_term_item: parliamentary_term_item, }
+  end
+
+  private
+
+  def query_format
+    <<~SPARQL
+      SELECT DISTINCT
+        ?country
+      WHERE {
+        BIND(wd:%<position_held_item>s AS ?position)
+        BIND(wd:%<parliamentary_term_item>s AS ?term)
+
+        OPTIONAL { ?position wdt:P17 ?position_country . }
+        OPTIONAL { ?term wdt:P17 ?term_country . }
+
+        BIND(COALESCE(?position_country, ?term_country) AS ?country)
+
+        FILTER(?position_country = ?term_country || !BOUND(?position_country) || !BOUND(?term_country))
+      }
+      LIMIT 1
+    SPARQL
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,3 +44,9 @@ en:
         new_item_description_en: Item description
         new_item_label_language: Item label language
         csv_source_url: CSV source URL
+    errors:
+      models:
+        page:
+          attributes:
+            country_item:
+              blank: could not be derived from the position_held_item or parliamentary_term_item. Please check they have a P17 country property.

--- a/spec/lib/wiki_page_template_tag_spec.rb
+++ b/spec/lib/wiki_page_template_tag_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe WikiPageTemplateTag, type: :service do
   let(:wiki_template) do
     <<~TEMPLATE
       {{#{subject.send(:wiki_template_name)}
-      |country_item=Q16
       |position_held_item=Q123
       |parliamentary_term_item=Q456
       |csv_source_url=https://example.com/members.csv
@@ -43,7 +42,6 @@ RSpec.describe WikiPageTemplateTag, type: :service do
   describe '#page_attributes' do
     it 'parses the correct attributes from the template' do
       expect(subject.page_attributes).to eq(
-        country_item:            'Q16',
         position_held_item:      'Q123',
         parliamentary_term_item: 'Q456',
         csv_source_url:          'https://example.com/members.csv',

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -57,11 +57,26 @@ RSpec.describe Page, type: :model do
     end
 
     before do
+      allow(RetrieveCountry).to receive(:run).with('Q2', 'Q3').and_return(
+        OpenStruct.new(country: 'Q4')
+      )
       allow(RetrieveItems).to receive(:run).with('Q2', 'Q3', 'Q4').and_return(
         'Q2' => OpenStruct.new(label: 'Position'),
         'Q3' => OpenStruct.new(label: 'Term'),
         'Q4' => OpenStruct.new(label: 'Country')
       )
+    end
+
+    context 'position held and parliamentary term items changed' do
+      before do
+        allow(page).to receive(:position_held_item_changed?) { true }
+        allow(page).to receive(:parliamentary_term_item_changed?) { true }
+      end
+
+      it 'should set country item' do
+        page.country_item = nil
+        expect { page.valid? }.to change(page, :country_item).to('Q4')
+      end
     end
 
     context 'position held item changed' do

--- a/spec/services/retrieve_country_spec.rb
+++ b/spec/services/retrieve_country_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RetrieveCountry, type: :service do
+  let(:service) { RetrieveCountry.new('Q1', 'Q2') }
+
+  describe 'initialisation' do
+    it 'assigns position_held_item instance variable' do
+      expect(service.position_held_item).to eq 'Q1'
+    end
+
+    it 'assigns parliamentary_term_item instance variable' do
+      expect(service.parliamentary_term_item).to eq 'Q2'
+    end
+  end
+
+  describe '#run' do
+    it 'calls run_query with substituted position_held_item' do
+      allow(service).to receive(:query_format).and_return('%<position_held_item>s')
+      expect(service).to receive(:run_query).with('Q1').and_return([])
+      service.run
+    end
+
+    it 'calls run_query with substituted parliamentary_term_item' do
+      allow(service).to receive(:query_format).and_return('%<parliamentary_term_item>s')
+      expect(service).to receive(:run_query).with('Q2').and_return([])
+      service.run
+    end
+
+    it 'returns the first result' do
+      first = double('SPARQL result')
+      expect(service).to receive(:run_query).and_return([first])
+      expect(service.run).to eq first
+    end
+  end
+end

--- a/spec/support/page_setup.rb
+++ b/spec/support/page_setup.rb
@@ -2,6 +2,8 @@
 
 RSpec.configure do |config|
   config.before do
+    country_result = Struct.new(:country)
+    allow(RetrieveCountry).to receive(:run).and_return(country_result.new('P16'))
     allow(RetrieveItems).to receive(:run).and_return({})
   end
 end


### PR DESCRIPTION
Fixes #459 

Checklist from #531

> - [x] store the position held item's country property (P17) as `Page#country_item`
> - [x] show warning when the given position held item doesn't have a country property, and ask the user to correct it on Wikidata before continuing.