### PR TITLE
[#588] Allow frontend to create parties and districts

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -78,8 +78,8 @@ class PagesController < ApplicationController
       :country_item, :country_code,
       :executive_position, :archived,
       :reference_url, :reference_url_title, :reference_url_language,
-      :csv_source_url,
-      :new_item_description_en, :new_item_label_language
+      :csv_source_url, :csv_source_language,
+      :new_item_description_en
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,7 +79,9 @@ class PagesController < ApplicationController
       :executive_position, :archived,
       :reference_url, :reference_url_title, :reference_url_language,
       :csv_source_url, :csv_source_language,
-      :new_item_description_en
+      :new_item_description_en,
+      :new_party_description_en, :new_party_instance_of_item,
+      :new_district_description_en, :new_district_instance_of_item
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -73,13 +73,14 @@ class PagesController < ApplicationController
 
   # Only allow a trusted parameter "white list" through.
   def page_params
-    params.require(:page).permit(:title, :position_held_item,
-                                 :parliamentary_term_item, :reference_url,
-                                 :country_item, :country_code,
-                                 :csv_source_url, :executive_position,
-                                 :reference_url_title, :reference_url_language,
-                                 :archived, :new_item_description_en,
-                                 :new_item_label_language)
+    params.require(:page).permit(
+      :title, :position_held_item, :parliamentary_term_item,
+      :country_item, :country_code,
+      :executive_position, :archived,
+      :reference_url, :reference_url_title, :reference_url_language,
+      :csv_source_url,
+      :new_item_description_en, :new_item_label_language
+    )
   end
 
   def new_page_params

--- a/app/javascript/components/reconcilable.html
+++ b/app/javascript/components/reconcilable.html
@@ -44,8 +44,8 @@
           <p v-html="wpResult.snippetHTML" class="description"></p>
         </div>
       </li>
-      <li v-if="this.searchResourceType === 'person'">
-        <button v-on:click="createPerson()" class="mw-ui-button">Create new item: {{ searchTerm }}</button>
+      <li>
+        <button v-on:click="create(searchResourceType)" class="mw-ui-button">Create new item: {{ searchTerm }}</button>
       </li>
     </ul>
   </span>

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -129,16 +129,33 @@ export default template({
         }
       )
     },
-    createPerson: function () {
-      wikidataClient.createPerson(
-        {
-          value: this.searchTerm
-        },
-        {
-          lang: 'en',
-          value: this.page.new_item_description_en
-        }
+    create: function (resourceType) {
+      switch (resourceType) {
+        case 'person':
+          this.createItem(wikidataClient.getPersonCreateData, 'en', this.page.new_item_description_en)
+          break
+        case 'party':
+          this.createItem(wikidataClient.getCreateData, 'en', this.page.new_party_description_en, this.page.country_item, this.page.new_party_instance_of_item)
+          break
+        case 'district':
+          this.createItem(wikidataClient.getCreateData, 'en', this.page.new_district_description_en, this.page.country_item, this.page.new_district_instance_of_item)
+          break
+      }
+    },
+    createItem: function (fn, descriptionLang, description, countryItem = null, instanceOfItem = null) {
+      wikidataClient.createItem(
+        fn(
+          {
             lang: this.page.csv_source_language,
+            value: this.searchTerm
+          },
+          {
+            lang: descriptionLang,
+            value: description
+          },
+          countryItem,
+          instanceOfItem
+        )
       ).then(createdItemData => {
         this.reconcileWithItem(createdItemData.item)
       })

--- a/app/javascript/components/reconcilable.js
+++ b/app/javascript/components/reconcilable.js
@@ -132,13 +132,13 @@ export default template({
     createPerson: function () {
       wikidataClient.createPerson(
         {
-          lang: this.page.new_item_label_language,
           value: this.searchTerm
         },
         {
           lang: 'en',
           value: this.page.new_item_description_en
         }
+            lang: this.page.csv_source_language,
       ).then(createdItemData => {
         this.reconcileWithItem(createdItemData.item)
       })

--- a/app/javascript/wikiapi.js
+++ b/app/javascript/wikiapi.js
@@ -487,6 +487,7 @@ var wikidata = function (spec) {
         'parliamentary term': 'P2937',
         'title': 'P1476',
         'language of work or name': 'P407',
+        'country': 'P17',
         'instance of': 'P31',
         'start time': 'P580',
         'end time': 'P582'
@@ -502,6 +503,7 @@ var wikidata = function (spec) {
         'parliamentary term': 'P70901',
         'title': 'P77107',
         'language of work or name': 'P77090',
+        'country': 'P17',
         'instance of': 'P82',
         'start time': 'P355',
         'end time': 'P356'
@@ -521,6 +523,7 @@ var wikidata = function (spec) {
         'parliamentary term': 'P70901',
         'title': 'P77107',
         'language of work or name': 'P77090',
+        'country': 'P17',
         'instance of': 'P82',
         'start time': 'P355',
         'end time': 'P356'
@@ -556,7 +559,7 @@ var wikidata = function (spec) {
     }[that.serverName][itemLabel]
   }
 
-  function getPersonCreateData (label, description) {
+  that.getPersonCreateData = function (label, description) {
     var data = {
       labels: {},
       descriptions: {}
@@ -598,10 +601,52 @@ var wikidata = function (spec) {
     return JSON.stringify(data)
   }
 
-  that.createPerson = function (personLabel, personDescription) {
+  that.getCreateData = function (label, description, countryItem, instanceOfItem) {
+    var data = {
+      labels: {},
+      descriptions: {}
+    }
+    data.labels[label.lang] = {
+      language: label.lang,
+      value: label.value
+    }
+    data.descriptions[description.lang] = {
+      language: description.lang,
+      value: description.value
+    }
+    data.claims = [
+      {
+        'mainsnak': {
+          'snaktype': 'value',
+          'property': that.getPropertyID('country'),
+          'datavalue': {
+            'value': getItemValue(countryItem),
+            'type': 'wikibase-entityid'
+          }
+        },
+        'type': 'statement',
+        'rank': 'normal'
+      },
+      {
+        'mainsnak': {
+          'snaktype': 'value',
+          'property': that.getPropertyID('instance of'),
+          'datavalue': {
+            'value': getItemValue(instanceOfItem),
+            'type': 'wikibase-entityid'
+          }
+        },
+        'type': 'statement',
+        'rank': 'normal'
+      }
+    ]
+    return JSON.stringify(data)
+  }
+
+  that.createItem = function (data) {
     return that.ajaxAPI(true, 'wbeditentity', {
       new: 'item',
-      data: getPersonCreateData(personLabel, personDescription),
+      data: data,
       summary: this.summary()
     }).then(function (result) {
       return {

--- a/app/lib/wiki_page_template_tag.rb
+++ b/app/lib/wiki_page_template_tag.rb
@@ -15,8 +15,8 @@ class WikiPageTemplateTag
       position_held_item:      params[:position_held_item],
       parliamentary_term_item: params[:parliamentary_term_item],
       csv_source_url:          params[:csv_source_url],
+      csv_source_language:     params[:csv_source_language],
       new_item_description_en: params[:new_item_description_en],
-      new_item_label_language: params[:new_item_label_language],
     }
   end
 

--- a/app/lib/wiki_page_template_tag.rb
+++ b/app/lib/wiki_page_template_tag.rb
@@ -12,11 +12,15 @@ class WikiPageTemplateTag
 
   def page_attributes
     {
-      position_held_item:      params[:position_held_item],
-      parliamentary_term_item: params[:parliamentary_term_item],
-      csv_source_url:          params[:csv_source_url],
-      csv_source_language:     params[:csv_source_language],
-      new_item_description_en: params[:new_item_description_en],
+      position_held_item:            params[:position_held_item],
+      parliamentary_term_item:       params[:parliamentary_term_item],
+      csv_source_url:                params[:csv_source_url],
+      csv_source_language:           params[:csv_source_language],
+      new_item_description_en:       params[:new_item_description_en],
+      new_party_description_en:      params[:new_party_description_en],
+      new_party_instance_of_item:    params[:new_party_instance_of_item],
+      new_district_description_en:   params[:new_district_description_en],
+      new_district_instance_of_item: params[:new_district_instance_of_item],
     }
   end
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -17,6 +17,8 @@ class Page < ApplicationRecord
   before_validation :set_position_held_name, if: :position_held_item_changed?
   before_validation :set_parliamentary_term_name, if: :parliamentary_term_item_changed?
   before_validation :set_country_name, if: :country_item_changed?
+  before_validation :set_new_party_instance_of_name, if: :new_party_instance_of_item_changed?
+  before_validation :set_new_district_instance_of_name, if: :new_district_instance_of_item_changed?
 
   def from_suggestions_store?
     URI.parse(csv_source_url).host == URI.parse(SuggestionsStore::Request::URL).host
@@ -42,7 +44,18 @@ class Page < ApplicationRecord
     self.country_name = item_data[country_item]&.label
   end
 
+  def set_new_party_instance_of_name
+    self.new_party_instance_of_name = item_data[new_party_instance_of_item]&.label
+  end
+
+  def set_new_district_instance_of_name
+    self.new_district_instance_of_name = item_data[new_district_instance_of_item]&.label
+  end
+
   def item_data
-    @item_data ||= RetrieveItems.run(position_held_item, parliamentary_term_item, country_item)
+    @item_data ||= RetrieveItems.run(
+      position_held_item, parliamentary_term_item, country_item,
+      new_party_instance_of_item, new_district_instance_of_item
+    )
   end
 end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -66,13 +66,6 @@
     </div>
     <%= f.error_span(:new_item_description_en) %>
   </div>
-  <div class="form-group">
-    <%= f.label :new_item_label_language, class: 'control-label col-lg-2' %>
-    <div class="col-lg-10">
-      <%= f.text_field :new_item_label_language, class: 'form-control' %>
-    </div>
-    <%= f.error_span(:new_item_label_language) %>
-  </div>
   <!--
   <div class="form-group">
     <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>
@@ -95,6 +88,13 @@
       <%= f.text_field :csv_source_url, class: 'form-control' %>
     </div>
     <%= f.error_span(:csv_source_url) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :csv_source_language, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :csv_source_language, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:csv_source_language) %>
   </div>
   <div class="form-check">
     <%= f.check_box :executive_position %>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -66,6 +66,34 @@
     </div>
     <%= f.error_span(:new_item_description_en) %>
   </div>
+  <div class="form-group">
+    <%= f.label :new_party_description_en, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_party_description_en, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_party_description_en) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :new_party_instance_of, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_party_instance_of, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_party_instance_of) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :new_district_description_en, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_district_description_en, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_district_description_en) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :new_district_instance_of, class: 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :new_district_instance_of, class: 'form-control' %>
+    </div>
+    <%= f.error_span(:new_district_instance_of) %>
+  </div>
   <!--
   <div class="form-group">
     <%= f.label :reference_url_title, class: 'control-label col-lg-2' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -10,8 +10,6 @@
       <th><%= model_class.human_attribute_name(:position_held_item) %></th>
       <th><%= model_class.human_attribute_name(:parliamentary_term_item) %></th>
       <th><%= model_class.human_attribute_name(:country_item) %></th>
-      <th><%= model_class.human_attribute_name(:new_item_description_en) %></th>
-      <th><%= model_class.human_attribute_name(:new_item_label_language) %></th>
       <th><%= model_class.human_attribute_name(:executive_position) %></th>
       <th><%= model_class.human_attribute_name(:archived) %></th>
       <th><%= t '.actions', default: t("helpers.actions") %></th>
@@ -25,8 +23,6 @@
         <td><%= link_to_wiki page.position_held_name, page.position_held_item %></td>
         <td><%= link_to_wiki page.parliamentary_term_name, page.parliamentary_term_item %></td>
         <td><%= link_to_wiki page.country_name, page.country_item %></td>
-        <td><%= page.new_item_description_en %></td>
-        <td><%= page.new_item_label_language %></td>
         <td><%= page.executive_position %></td>
         <td><%= page.archived %></td>
         <td>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -30,10 +30,10 @@
   -->
   <dt><strong><%= model_class.human_attribute_name(:csv_source_url) %>:</strong></dt>
   <dd><%= link_to @page.csv_source_url %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:csv_source_language) %>:</strong></dt>
+  <dd><%= @page.csv_source_language %></dd>
   <dt><strong><%= model_class.human_attribute_name(:new_item_description_en) %>:</strong></dt>
   <dd><%= @page.new_item_description_en %></dd>
-  <dt><strong><%= model_class.human_attribute_name(:new_item_label_language) %>:</strong></dt>
-  <dd><%= @page.new_item_label_language %></dd>
   <dt><strong><%= model_class.human_attribute_name(:executive_position) %>:</strong></dt>
   <dd><%= @page.executive_position %></dd>
   <dt><strong><%= model_class.human_attribute_name(:archived) %>:</strong></dt>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -34,6 +34,14 @@
   <dd><%= @page.csv_source_language %></dd>
   <dt><strong><%= model_class.human_attribute_name(:new_item_description_en) %>:</strong></dt>
   <dd><%= @page.new_item_description_en %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_party_description_en) %>:</strong></dt>
+  <dd><%= @page.new_party_description_en %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_party_instance_of) %>:</strong></dt>
+  <dd><%= @page.new_party_instance_of %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_district_description_en) %>:</strong></dt>
+  <dd><%= @page.new_district_description_en %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:new_district_instance_of) %>:</strong></dt>
+  <dd><%= @page.new_district_instance_of %></dd>
   <dt><strong><%= model_class.human_attribute_name(:executive_position) %>:</strong></dt>
   <dd><%= @page.executive_position %></dd>
   <dt><strong><%= model_class.human_attribute_name(:archived) %>:</strong></dt>

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -46,6 +46,8 @@ json.statements @classifier.statements do |statement|
 end
 
 json.page @classifier.page,
-          :position_held_item, :executive_position,
+          :position_held_item, :executive_position, :country_item,
           :reference_url, :reference_url_title, :reference_url_language,
-          :csv_source_language, :new_item_description_en
+          :csv_source_language, :new_item_description_en,
+          :new_party_description_en, :new_party_instance_of_item,
+          :new_district_description_en, :new_district_instance_of_item

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -45,4 +45,7 @@ json.statements @classifier.statements do |statement|
   json.bulk_update @bulk_update
 end
 
-json.page @classifier.page, :reference_url, :position_held_item, :executive_position, :reference_url_title, :reference_url_language, :new_item_description_en, :new_item_label_language
+json.page @classifier.page,
+          :position_held_item, :executive_position,
+          :reference_url, :reference_url_title, :reference_url_language,
+          :new_item_label_language, :new_item_description_en

--- a/app/views/statements/index.json.jbuilder
+++ b/app/views/statements/index.json.jbuilder
@@ -48,4 +48,4 @@ end
 json.page @classifier.page,
           :position_held_item, :executive_position,
           :reference_url, :reference_url_title, :reference_url_language,
-          :new_item_label_language, :new_item_description_en
+          :csv_source_language, :new_item_description_en

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
         reference_url_title: Reference URL title
         reference_url_language: Reference URL language
         new_item_description_en: Item description
-        new_item_label_language: Item label language
+        csv_source_language: CSV source language
         csv_source_url: CSV source URL
     errors:
       models:

--- a/db/migrate/20190306122639_rename_pages_label_language.rb
+++ b/db/migrate/20190306122639_rename_pages_label_language.rb
@@ -1,0 +1,5 @@
+class RenamePagesLabelLanguage < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :pages, :new_item_label_language, :csv_source_language
+  end
+end

--- a/db/migrate/20190306125511_add_party_and_district_fields_to_pages.rb
+++ b/db/migrate/20190306125511_add_party_and_district_fields_to_pages.rb
@@ -1,0 +1,10 @@
+class AddPartyAndDistrictFieldsToPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :new_party_description_en, :string
+    add_column :pages, :new_party_instance_of_item, :string
+    add_column :pages, :new_party_instance_of_name, :string
+    add_column :pages, :new_district_description_en, :string
+    add_column :pages, :new_district_instance_of_item, :string
+    add_column :pages, :new_district_instance_of_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_154548) do
+ActiveRecord::Schema.define(version: 2019_03_06_122639) do
 
   create_table "pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_154548) do
     t.integer "hash_epoch", default: 3
     t.boolean "archived", default: false, null: false
     t.string "new_item_description_en"
-    t.string "new_item_label_language"
+    t.string "csv_source_language"
     t.string "country_item"
     t.string "country_name"
     t.string "country_code"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_06_122639) do
+ActiveRecord::Schema.define(version: 2019_03_06_125511) do
 
   create_table "pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
@@ -32,6 +32,12 @@ ActiveRecord::Schema.define(version: 2019_03_06_122639) do
     t.string "country_item"
     t.string "country_name"
     t.string "country_code"
+    t.string "new_party_description_en"
+    t.string "new_party_instance_of_item"
+    t.string "new_party_instance_of_name"
+    t.string "new_district_description_en"
+    t.string "new_district_instance_of_item"
+    t.string "new_district_instance_of_name"
   end
 
   create_table "reconciliations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/controllers/wikidata_page_controller_spec.rb
+++ b/spec/controllers/wikidata_page_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe WikidataPageController, type: :controller do
           country_code:            'ca',
           parliamentary_term_item: 'Q456',
           csv_source_url:          'https://example.com/members.csv',
+          csv_source_language:     'en',
           new_item_description_en: 'Canadian politician',
-          new_item_label_language: 'en',
         },
         update_page:     true,
         wikidata_url:    wikidata_url

--- a/spec/lib/wiki_page_template_tag_spec.rb
+++ b/spec/lib/wiki_page_template_tag_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe WikiPageTemplateTag, type: :service do
       |position_held_item=Q123
       |parliamentary_term_item=Q456
       |csv_source_url=https://example.com/members.csv
+      |csv_source_language=en
       |new_item_description_en=Canadian politician
-      |new_item_label_language=en
       }}
     TEMPLATE
   end
@@ -45,8 +45,8 @@ RSpec.describe WikiPageTemplateTag, type: :service do
         position_held_item:      'Q123',
         parliamentary_term_item: 'Q456',
         csv_source_url:          'https://example.com/members.csv',
-        new_item_description_en: 'Canadian politician',
-        new_item_label_language: 'en'
+        csv_source_language:     'en',
+        new_item_description_en: 'Canadian politician'
       )
     end
   end

--- a/spec/lib/wiki_page_template_tag_spec.rb
+++ b/spec/lib/wiki_page_template_tag_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe WikiPageTemplateTag, type: :service do
       |csv_source_url=https://example.com/members.csv
       |csv_source_language=en
       |new_item_description_en=Canadian politician
+      |new_party_description_en=political party in Canada
+      |new_party_instance_of_item=Q777
+      |new_district_description_en=electrial district in Canada
+      |new_district_instance_of_item=Q888
       }}
     TEMPLATE
   end
@@ -42,11 +46,15 @@ RSpec.describe WikiPageTemplateTag, type: :service do
   describe '#page_attributes' do
     it 'parses the correct attributes from the template' do
       expect(subject.page_attributes).to eq(
-        position_held_item:      'Q123',
-        parliamentary_term_item: 'Q456',
-        csv_source_url:          'https://example.com/members.csv',
-        csv_source_language:     'en',
-        new_item_description_en: 'Canadian politician'
+        position_held_item:            'Q123',
+        parliamentary_term_item:       'Q456',
+        csv_source_url:                'https://example.com/members.csv',
+        csv_source_language:           'en',
+        new_item_description_en:       'Canadian politician',
+        new_party_description_en:      'political party in Canada',
+        new_party_instance_of_item:    'Q777',
+        new_district_description_en:   'electrial district in Canada',
+        new_district_instance_of_item: 'Q888'
       )
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -53,17 +53,22 @@ RSpec.describe Page, type: :model do
 
   describe 'before validation' do
     let(:page) do
-      build(:page, position_held_item: 'Q2', parliamentary_term_item: 'Q3', country_item: 'Q4')
+      build(:page,
+            position_held_item: 'Q2', parliamentary_term_item: 'Q3',
+            country_item: 'Q4', new_party_instance_of_item: 'Q5',
+            new_district_instance_of_item: 'Q6')
     end
 
     before do
       allow(RetrieveCountry).to receive(:run).with('Q2', 'Q3').and_return(
         OpenStruct.new(country: 'Q4')
       )
-      allow(RetrieveItems).to receive(:run).with('Q2', 'Q3', 'Q4').and_return(
+      allow(RetrieveItems).to receive(:run).with('Q2', 'Q3', 'Q4', 'Q5', 'Q6').and_return(
         'Q2' => OpenStruct.new(label: 'Position'),
         'Q3' => OpenStruct.new(label: 'Term'),
-        'Q4' => OpenStruct.new(label: 'Country')
+        'Q4' => OpenStruct.new(label: 'Country'),
+        'Q5' => OpenStruct.new(label: 'Party'),
+        'Q6' => OpenStruct.new(label: 'District')
       )
     end
 
@@ -124,6 +129,38 @@ RSpec.describe Page, type: :model do
 
       it 'should not set country name' do
         expect { page.valid? }.to_not change(page, :country_name)
+      end
+    end
+
+    context 'new party instance of item changed' do
+      before { allow(page).to receive(:new_party_instance_of_item_changed?) { true } }
+
+      it 'should set new party instance of name' do
+        expect { page.valid? }.to change(page, :new_party_instance_of_name).to('Party')
+      end
+    end
+
+    context 'new party instance of item is unchanged' do
+      before { allow(page).to receive(:new_party_instance_of_item_changed?) { false } }
+
+      it 'should not set new party instance of name' do
+        expect { page.valid? }.to_not change(page, :new_party_instance_of_name)
+      end
+    end
+
+    context 'new district instance of item changed' do
+      before { allow(page).to receive(:new_district_instance_of_item_changed?) { true } }
+
+      it 'should set new district instance of name' do
+        expect { page.valid? }.to change(page, :new_district_instance_of_name).to('District')
+      end
+    end
+
+    context 'new district instance of item is unchanged' do
+      before { allow(page).to receive(:new_district_instance_of_item_changed?) { false } }
+
+      it 'should not set new district instance of name' do
+        expect { page.valid? }.to_not change(page, :new_district_instance_of_name)
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe Page, type: :model do
       end
     end
 
-    context 'position held item is unchanged' do
+    context 'parliamentary term item is unchanged' do
       before { allow(page).to receive(:parliamentary_term_item_changed?) { false } }
 
-      it 'should not set position held name' do
+      it 'should not set parliamentary term name' do
         expect { page.valid? }.to_not change(page, :parliamentary_term_name)
       end
     end
@@ -119,10 +119,10 @@ RSpec.describe Page, type: :model do
       end
     end
 
-    context 'position held item is unchanged' do
+    context 'country item is unchanged' do
       before { allow(page).to receive(:country_item_changed?) { false } }
 
-      it 'should not set position held name' do
+      it 'should not set country name' do
         expect { page.valid? }.to_not change(page, :country_name)
       end
     end


### PR DESCRIPTION
Fixes #588 will split out Wiki template sensible defaults into separate ticket/PR #624 
Requires #622 

![create-parties-districts-2](https://user-images.githubusercontent.com/5426/53970336-5c851680-40f2-11e9-840b-c84a1527ecc0.gif)

Demo using the API proxy and test Wikidata instance.

Created:
- https://test.wikidata.org/wiki/Q197895
- https://test.wikidata.org/wiki/Q197896
