### PR TITLE
[#655] Parse dates from SPARQL queries

### DIFF
--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -12,7 +12,12 @@ class RetrievePositionData < ServiceBase
   end
 
   def run
-    run_query(query)
+    run_query(query).map do |row|
+      %i[position_start position_end term_start term_end].each do |key|
+        row[key] = Date.parse(row[key]) if row[key]
+      end
+      row
+    end
   end
 
   def query

--- a/app/services/retrieve_term_data.rb
+++ b/app/services/retrieve_term_data.rb
@@ -11,7 +11,13 @@ class RetrieveTermData < ServiceBase
   end
 
   def run
-    run_query(query).first
+    result = run_query(query).first
+
+    %i[start end previous_term_end next_term_start].each do |key|
+      result[key] = Date.parse(result[key]) if result[key]
+    end
+
+    result
   end
 
   def query

--- a/spec/services/retrieve_position_data_spec.rb
+++ b/spec/services/retrieve_position_data_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe RetrievePositionData, type: :service do
   describe '#run' do
     it 'calls run_query with substituted position_held_items' do
       allow(service).to receive(:query_format).and_return('%<position_held_items>s')
-      expect(service).to receive(:run_query).with('(wd:Q1)')
+      expect(service).to receive(:run_query).with('(wd:Q1)').and_return([])
       service.run
     end
 
     context 'with person_item' do
       it 'calls run_query with substituted person_bind' do
         allow(service).to receive(:query_format).and_return('%<person_bind>s')
-        expect(service).to receive(:run_query).with('BIND(wd:Q2 AS ?person)')
+        expect(service).to receive(:run_query).with('BIND(wd:Q2 AS ?person)').and_return([])
         service.run
       end
     end
@@ -43,9 +43,22 @@ RSpec.describe RetrievePositionData, type: :service do
 
       it 'calls run_query with no person_bind' do
         allow(service).to receive(:query_format).and_return('%<person_bind>s')
-        expect(service).to receive(:run_query).with('')
+        expect(service).to receive(:run_query).with('').and_return([])
         service.run
       end
+    end
+
+    it 'type cast string date values' do
+      input = {
+        position_start: '2019-01-01', position_end: '2019-02-01',
+        term_start: '2018-01-01', term_end: '2018-02-01',
+      }
+      output = {
+        position_start: Date.new(2019, 1, 1), position_end: Date.new(2019, 2, 1),
+        term_start: Date.new(2018, 1, 1), term_end: Date.new(2018, 2, 1),
+      }
+      allow(service).to receive(:run_query).and_return([input])
+      expect(service.run).to match_array([output])
     end
   end
 end


### PR DESCRIPTION
This ensures when comparing dates in the membership-comparison gem we're
comparing dates with dates, instead of dates with strings.

Fixes #655