### PR TITLE
Pass correct data to membership comparison gem

### DIFF
--- a/app/services/statement_classifier.rb
+++ b/app/services/statement_classifier.rb
@@ -44,7 +44,7 @@ class StatementClassifier
       term:     suggested_term,
       person:   suggested_person,
       party:    suggested_party,
-      district: suggested_dates
+      district: suggested_district
     ).merge(suggested_dates)
   end
 


### PR DESCRIPTION
This was breaking the district comparison and classify statements as
exact matches when they weren't.

Fixes: https://github.com/mysociety/verification-pages/issues/636