### PR TITLE
Only parse dates which looks like a date

### DIFF
--- a/app/services/retrieve_position_data.rb
+++ b/app/services/retrieve_position_data.rb
@@ -14,7 +14,7 @@ class RetrievePositionData < ServiceBase
   def run
     run_query(query).map do |row|
       %i[position_start position_end term_start term_end].each do |key|
-        row[key] = Date.parse(row[key]) if row[key]
+        row[key] = (Date.parse(row[key]) if /\d{4}-\d{2}-\d{2}/.match?(row[key]))
       end
       row
     end

--- a/app/services/retrieve_term_data.rb
+++ b/app/services/retrieve_term_data.rb
@@ -14,7 +14,7 @@ class RetrieveTermData < ServiceBase
     result = run_query(query).first
 
     %i[start end previous_term_end next_term_start].each do |key|
-      result[key] = Date.parse(result[key]) if result[key]
+      result[key] = (Date.parse(result[key]) if /\d{4}-\d{2}-\d{2}/.match?(result[key]))
     end
 
     result


### PR DESCRIPTION
SPARQL might sometimes return a invalid date, EG for the next_term_start
if there isn't a next term.

Invalid dates are set to nil.